### PR TITLE
feat: 添加补档前先检查作者是否拒绝补档与对应管理指令

### DIFF
--- a/src/core/index.js
+++ b/src/core/index.js
@@ -121,6 +121,7 @@ const deleteRebuiltMessageCommand = require('../modules/threadRebuilder/commands
 // 自助文件上传系统命令
 const uploadCommand = require('../modules/selfFileUpload/commands/uploadFile');
 const whoisCommand = require('../modules/selfFileUpload/commands/queryAnonymousLog');
+const manageOptOutCommand = require('../modules/selfFileUpload/commands/manageOptOut.js');
 
 // 补卡系统命令
 const processBackupCardsCommand = require('../modules/backupCards/commands/processBackupCards');
@@ -246,6 +247,7 @@ client.commands.set(updateVotingCandidatesCommand.data.name, updateVotingCandida
 // 自助文件上传系统命令
 client.commands.set(uploadCommand.data.name, uploadCommand);
 client.commands.set(whoisCommand.data.name, whoisCommand);
+client.commands.set(manageOptOutCommand.data.name, manageOptOutCommand);
 
 client.once(Events.ClientReady, async (readyClient) => {
     await clientReadyHandler(readyClient);
@@ -276,7 +278,7 @@ client.once(Events.ClientReady, async (readyClient) => {
     console.log('🏆 赛事管理系统已加载');
     console.log('🧹 自动消息清理系统已加载');
     console.log('🗳️ 选举系统已完全加载 (包含16个命令)');
-    console.log('🎴 补卡管理系统已加载 (包含2个命令)');
+    console.log('🎴 补卡管理系统已加载 (包含3个命令)');
 })
 
 client.on(Events.InteractionCreate, interactionCreateHandler)

--- a/src/modules/selfFileUpload/commands/manageOptOut.js
+++ b/src/modules/selfFileUpload/commands/manageOptOut.js
@@ -1,0 +1,88 @@
+const { SlashCommandBuilder } = require('discord.js');
+const { checkAdminPermission, getPermissionDeniedMessage } = require('../../../core/utils/permissionManager');
+const {
+    addUserToOptOutList,
+    removeUserFromOptOutList,
+    readOptOutList,
+} = require('../../../core/utils/database');
+const { createPaginatedList } = require('../services/paginationService');
+const { batchAddUsersFromExcel } = require('../services/batchAddService');
+
+module.exports = {
+    data: new SlashCommandBuilder()
+        .setName('管理自助补档屏蔽')
+        .setDescription('管理不允许他人在其帖子下使用自助补档功能的用户列表 (仅管理员)。')
+        .setDefaultMemberPermissions(0)
+        .addSubcommand(subcommand =>
+            subcommand.setName('添加').setDescription('添加一个用户到自助补档屏蔽列表。')
+                .addUserOption(option => option.setName('用户').setDescription('要添加的用户').setRequired(true)))
+        .addSubcommand(subcommand =>
+            subcommand.setName('移除').setDescription('从自助补档屏蔽列表移除一个用户。')
+                .addUserOption(option => option.setName('用户').setDescription('要移除的用户').setRequired(true)))
+        .addSubcommand(subcommand =>
+            subcommand.setName('列表').setDescription('查看当前的自助补档屏蔽列表（带翻页功能）。'))
+        .addSubcommand(subcommand =>
+            subcommand.setName('批量添加').setDescription('从Excel文件批量添加用户到屏蔽列表。')
+                .addAttachmentOption(option => option.setName('excel文件').setDescription('包含用户ID列表的Excel文件').setRequired(true))),
+
+    async execute(interaction) {
+        if (!checkAdminPermission(interaction.member)) {
+            return interaction.reply({ content: getPermissionDeniedMessage(), ephemeral: true });
+        }
+
+        await interaction.deferReply({ ephemeral: true });
+        const subcommand = interaction.options.getSubcommand();
+
+        try {
+            switch (subcommand) {
+                case '添加': await handleAdd(interaction); break;
+                case '移除': await handleRemove(interaction); break;
+                case '列表': await handleList(interaction); break;
+                case '批量添加': await handleBatchAdd(interaction); break;
+            }
+        } catch (error) {
+            console.error('管理自助补档屏蔽列表时出错:', error);
+            await interaction.editReply('❌ 操作时发生内部错误。');
+        }
+    },
+};
+
+async function handleAdd(interaction) {
+    const targetUser = interaction.options.getUser('用户');
+    const added = await addUserToOptOutList(targetUser.id);
+    await interaction.editReply(added ? `✅ 已成功将用户 **${targetUser.tag}** 添加到自助补档屏蔽列表。` : `ℹ️ 用户 **${targetUser.tag}** 已在屏蔽列表中。`);
+}
+
+async function handleRemove(interaction) {
+    const targetUser = interaction.options.getUser('用户');
+    const removed = await removeUserFromOptOutList(targetUser.id);
+    await interaction.editReply(removed ? `✅ 已成功从自助补档屏蔽列表移除用户 **${targetUser.tag}**。` : `ℹ️ 用户 **${targetUser.tag}** 不在屏蔽列表中。`);
+}
+
+async function handleBatchAdd(interaction) {
+    const attachment = interaction.options.getAttachment('excel文件');
+    await interaction.editReply('🔄 正在处理文件，请稍候...');
+    const result = await batchAddUsersFromExcel(attachment);
+
+    if (result.error) {
+        return interaction.editReply(result.error);
+    }
+    await interaction.editReply(`✅ **批量添加完成！**\n\n- **成功添加**: ${result.addedCount} 个新用户\n- **跳过 (已存在)**: ${result.skippedCount} 个用户`);
+}
+
+async function handleList(interaction) {
+    const optOutList = await readOptOutList();
+    if (optOutList.length === 0) {
+        return interaction.editReply('📝 当前自助补档屏蔽列表为空。');
+    }
+
+    const users = await Promise.all(
+        optOutList.map(id => interaction.client.users.fetch(id).catch(() => ({ id, tag: '⚠️ 未知用户' })))
+    );
+
+    const formattedList = users.map((user, index) => `\`${index + 1}.\` ${user.tag} (\`${user.id}\`)`);
+
+    await createPaginatedList(interaction, formattedList, {
+        title: '🚫 自助补档屏蔽列表',
+    });
+}

--- a/src/modules/selfFileUpload/services/batchAddService.js
+++ b/src/modules/selfFileUpload/services/batchAddService.js
@@ -1,0 +1,53 @@
+const xlsx = require('xlsx');
+const { addUserToOptOutList } = require('../../../core/utils/database');
+// const fetch = require('node-fetch'); // <--- 移除这一行
+
+/**
+ * 从Excel文件批量添加用户ID到屏蔽列表。
+ * @param {import('discord.js').Attachment} attachment - The Excel file attachment.
+ * @returns {Promise<{addedCount: number, skippedCount: number, error?: string}>} - The result of the batch operation.
+ */
+async function batchAddUsersFromExcel(attachment) {
+    if (!attachment.name.endsWith('.xlsx') && !attachment.name.endsWith('.xls')) {
+        return { addedCount: 0, skippedCount: 0, error: '❌ 请上传一个有效的Excel文件 (.xlsx 或 .xls)。' };
+    }
+
+    try {
+        const response = await fetch(attachment.url); // 直接使用全局的 fetch
+        if (!response.ok) throw new Error(`无法下载文件: ${response.statusText}`);
+        const buffer = await response.arrayBuffer(); 
+        const workbook = xlsx.read(buffer, { type: 'buffer' });
+        const sheetName = workbook.SheetNames[0];
+        const worksheet = workbook.Sheets[sheetName];
+        const data = xlsx.utils.sheet_to_json(worksheet, { header: 1 });
+
+        const idsToAdd = data
+            .map(row => row[0]) // 获取第一列的数据
+            .filter(id => id && /^\d+$/.test(String(id))) // 筛选出纯数字的ID
+            .map(String);
+
+        if (idsToAdd.length === 0) {
+            return { addedCount: 0, skippedCount: 0, error: '❌ 在Excel文件的第一列中没有找到有效的用户ID。' };
+        }
+
+        let addedCount = 0;
+        let skippedCount = 0;
+
+        for (const id of idsToAdd) {
+            const success = await addUserToOptOutList(id);
+            if (success) {
+                addedCount++;
+            } else {
+                skippedCount++;
+            }
+        }
+
+        return { addedCount, skippedCount };
+
+    } catch (error) {
+        console.error('处理Excel文件时出错:', error);
+        return { addedCount: 0, skippedCount: 0, error: '❌ 处理Excel文件时发生错误，请确保文件格式正确。' };
+    }
+}
+
+module.exports = { batchAddUsersFromExcel };

--- a/src/modules/selfFileUpload/services/paginationService.js
+++ b/src/modules/selfFileUpload/services/paginationService.js
@@ -1,0 +1,61 @@
+const { EmbedBuilder, ActionRowBuilder, ButtonBuilder, ButtonStyle } = require('discord.js');
+
+/**
+ * 创建一个可翻页的嵌入式消息来显示列表。
+ * @param {import('discord.js').CommandInteraction} interaction - The interaction object.
+ * @param {string[]} listItems - 要显示的字符串数组。
+ * @param {object} options - 配置选项。
+ * @param {string} options.title - Embed 的标题。
+ * @param {number} [options.itemsPerPage=10] - 每页显示的项目数。
+ * @param {number} [options.time=120000] - 收集器持续时间（毫秒）。
+ */
+async function createPaginatedList(interaction, listItems, { title, itemsPerPage = 10, time = 120000 }) {
+    const totalPages = Math.ceil(listItems.length / itemsPerPage);
+    let currentPage = 1;
+
+    const generateEmbed = (page) => {
+        const start = (page - 1) * itemsPerPage;
+        const end = start + itemsPerPage;
+        const currentItems = listItems.slice(start, end);
+        const description = currentItems.join('\n');
+
+        return new EmbedBuilder()
+            .setTitle(title)
+            .setDescription(description)
+            .setColor('#e74c3c')
+            .setFooter({ text: `第 ${page} / ${totalPages} 页 | 共 ${listItems.length} 个项目` })
+            .setTimestamp();
+    };
+
+    const generateButtons = (page) => {
+        return new ActionRowBuilder()
+            .addComponents(
+                new ButtonBuilder().setCustomId('prev_page').setLabel('◀️ 上一页').setStyle(ButtonStyle.Primary).setDisabled(page === 1),
+                new ButtonBuilder().setCustomId('next_page').setLabel('下一页 ▶️').setStyle(ButtonStyle.Primary).setDisabled(page === totalPages)
+            );
+    };
+
+    const embed = generateEmbed(currentPage);
+    const components = totalPages > 1 ? [generateButtons(currentPage)] : [];
+    const reply = await interaction.editReply({ embeds: [embed], components });
+
+    if (totalPages <= 1) return;
+
+    const collector = reply.createMessageComponentCollector({ time });
+
+    collector.on('collect', async i => {
+        if (i.user.id !== interaction.user.id) {
+            return i.reply({ content: '你不能操作这个按钮。', ephemeral: true });
+        }
+        i.customId === 'prev_page' ? currentPage-- : currentPage++;
+        await i.update({ embeds: [generateEmbed(currentPage)], components: [generateButtons(currentPage)] });
+    });
+
+    collector.on('end', () => {
+        const disabledButtons = generateButtons(currentPage);
+        disabledButtons.components.forEach(button => button.setDisabled(true));
+        interaction.editReply({ components: [disabledButtons] }).catch(() => {});
+    });
+}
+
+module.exports = { createPaginatedList };


### PR DESCRIPTION
根据之前使用自助补档的用户反馈“不知道哪些帖子能补，哪些帖子作者拒绝补档”，此 PR 旨在为服务器管理员提供一种管理工具，用以控制哪些作者的帖子不被“自助补档”功能所影响。

## 主要更改

- **新增管理员指令 `/管理自助补档屏蔽`**: 这是一个仅限管理员使用的指令组，包含以下子命令：
    - `添加`: 将指定用户添加到屏蔽列表。
    - `移除`: 从屏蔽列表移除指定用户。
    - `列表`: 以分页形式查看当前屏蔽列表中的所有用户，方便管理员浏览。
    - `批量添加`: 支持上传 Excel 文件 (`.xlsx` 或 `.xls`)，从文件的第一列批量导入用户ID到屏蔽列表，之前数据里拒绝补档的人数大概70个，人手一个个输入太麻烦。
- **核心逻辑更新**: “自助补档”功能在执行前，会先检查目标用户是否在屏蔽列表中。如果在，则会中止操作并提示补档者。
- **代码重构**: 将批量处理和分页列表的逻辑提取到了独立的 `services` 文件中 (`batchAddService.js`, `paginationService.js`)

## 截图 

<img width="837" height="302" alt="屏幕截图 2025-07-15 025237" src="https://github.com/user-attachments/assets/b96520e3-233b-4c84-a5a6-c7e9dbd40fb9" />
<img width="828" height="152" alt="屏幕截图 2025-07-15 025240" src="https://github.com/user-attachments/assets/6dc098f8-f669-4b2b-8ccd-2333d893d236" />
<img width="753" height="153" alt="屏幕截图 2025-07-15 025243" src="https://github.com/user-attachments/assets/fe57565d-da4b-4048-9823-fb87d5e8b4d6" />
<img width="701" height="148" alt="屏幕截图 2025-07-15 025247" src="https://github.com/user-attachments/assets/c92edd4f-cffc-403b-9ea8-77dcfcbb2b20" />
<img width="940" height="133" alt="屏幕截图 2025-07-15 025256" src="https://github.com/user-attachments/assets/00f9ed52-a33a-4518-a9b0-afd34e01e77d" />
<img width="722" height="154" alt="屏幕截图 2025-07-15 025308" src="https://github.com/user-attachments/assets/165a53d3-73be-4ae8-bedc-75b9cc5d7e60" />
