### PR TITLE
fix:修复自助补档黑名单的检查逻辑

### DIFF
--- a/src/modules/selfFileUpload/config/config.js
+++ b/src/modules/selfFileUpload/config/config.js
@@ -5,7 +5,7 @@ module.exports = {
     // 在这些论坛频道中，用户可以使用 /自助上传 命令
     // 将 'YOUR_FORUM_ID_HERE' 替换为实际的论坛频道ID
     ALLOWED_FORUM_IDS: [
-        'YOUR_FORUM_ID_HERE_1',
-        'YOUR_FORUM_ID_HERE_2',
+        'YOUR_FORUM_ID_HERE',
+        'YOUR_FORUM_ID_HERE',
     ],
 };


### PR DESCRIPTION

<img width="1288" height="338" alt="屏幕截图 2025-07-25 141753" src="https://github.com/user-attachments/assets/98bfec8e-1666-444c-8195-3b166813619b" />
修复之前的检查逻辑,之前没想起来帖子是bot发的,现在是检测首楼的所有@出来的用户
