### PR TITLE
fix(selfRole): 适配旧命令未抛弃的bug，使用新的数据库函数

### DIFF
--- a/src/core/utils/database.js
+++ b/src/core/utils/database.js
@@ -293,6 +293,17 @@ async function deleteSelfRoleApplication(messageId) {
     stmt.run(messageId);
 }
 
+/**
+ * 清空指定服务器和频道的所有用户活跃度数据。
+ * @param {string} guildId - 服务器ID。
+ * @param {string} channelId - 频道ID。
+ * @returns {Promise<void>}
+ */
+async function clearChannelActivity(guildId, channelId) {
+    const stmt = selfRoleDb.prepare('DELETE FROM user_activity WHERE guild_id = ? AND channel_id = ?');
+    stmt.run(guildId, channelId);
+}
+
 
 // --- 其他模块 (JSON) ---
 
@@ -1571,4 +1582,5 @@ module.exports = {
     getSelfRoleApplication,
     saveSelfRoleApplication,
     deleteSelfRoleApplication,
+    clearChannelActivity,
 };


### PR DESCRIPTION
本次提交修复了在db重构后出现的一个连锁 Bug
`/recalculateactivity` 命令仍在尝试调用已被 `saveUserActivityBatch` 函数取代的旧 `saveUserActivity` 函数。
- 重构了 `recalculateActivity.js`，使其使用新的 `saveUserActivityBatch` 和 `clearChannelActivity` 函数，确保其逻辑与新的数据处理行为一致
- 顺便在 `database.js` 中增加了 `clearChannelActivity` 函数，不然扫描时的重置数据功能又要错了