### PR TITLE
feat(selfRole): 新增活跃天数阈值检查功能

### DIFF
--- a/src/modules/selfRole/commands/recalculateActivity.js
+++ b/src/modules/selfRole/commands/recalculateActivity.js
@@ -1,7 +1,7 @@
 // src/modules/selfRole/commands/recalculateActivity.js
 
 const { SlashCommandBuilder, PermissionFlagsBits, EmbedBuilder, ChannelType } = require('discord.js');
-const { saveUserActivityBatch, clearChannelActivity } = require('../../../core/utils/database');
+const { saveUserActivityBatch, saveDailyUserActivityBatch, clearChannelActivity } = require('../../../core/utils/database');
 
 module.exports = {
     data: new SlashCommandBuilder()
@@ -51,6 +51,7 @@ module.exports = {
             let lastMessageId = null;
             let hasMoreMessages = true;
             const channelActivity = {}; // 只计算当前频道的增量
+            const dailyChannelActivity = {}; // 按日期分组的活跃度数据
 
             if (resetData) {
                 console.log(`[SelfRole] 🗑️ 重置频道 ${channel.name} 的活跃度数据...`);
@@ -75,24 +76,45 @@ module.exports = {
                     if (message.author.bot) continue;
 
                     const authorId = message.author.id;
+                    const messageDate = new Date(message.createdTimestamp).toISOString().split('T')[0]; // YYYY-MM-DD
+
+                    // 更新总体活跃度
                     if (!channelActivity[authorId]) {
                         channelActivity[authorId] = { messageCount: 0, mentionedCount: 0, mentioningCount: 0 };
                     }
                     channelActivity[authorId].messageCount++;
 
+                    // 更新每日活跃度
+                    if (!dailyChannelActivity[messageDate]) {
+                        dailyChannelActivity[messageDate] = {};
+                    }
+                    if (!dailyChannelActivity[messageDate][authorId]) {
+                        dailyChannelActivity[messageDate][authorId] = { messageCount: 0, mentionedCount: 0, mentioningCount: 0 };
+                    }
+                    dailyChannelActivity[messageDate][authorId].messageCount++;
+
                     // 检查是否为主动提及 (回复或@)
                     const isMentioning = message.reference !== null || message.mentions.users.size > 0 || message.mentions.roles.size > 0;
                     if (isMentioning) {
                         channelActivity[authorId].mentioningCount++;
+                        dailyChannelActivity[messageDate][authorId].mentioningCount++;
                     }
 
                     message.mentions.users.forEach(user => {
                         if (user.bot || user.id === authorId) return;
                         const mentionedId = user.id;
+
+                        // 更新总体被提及数
                         if (!channelActivity[mentionedId]) {
                             channelActivity[mentionedId] = { messageCount: 0, mentionedCount: 0, mentioningCount: 0 };
                         }
                         channelActivity[mentionedId].mentionedCount++;
+
+                        // 更新每日被提及数
+                        if (!dailyChannelActivity[messageDate][mentionedId]) {
+                            dailyChannelActivity[messageDate][mentionedId] = { messageCount: 0, mentionedCount: 0, mentioningCount: 0 };
+                        }
+                        dailyChannelActivity[messageDate][mentionedId].mentionedCount++;
                     });
                 }
 
@@ -109,6 +131,16 @@ module.exports = {
             };
 
             await saveUserActivityBatch(batchData);
+
+            // 保存每日活跃度数据
+            for (const date in dailyChannelActivity) {
+                const dailyBatchData = {
+                    [guildId]: {
+                        [channel.id]: dailyChannelActivity[date]
+                    }
+                };
+                await saveDailyUserActivityBatch(dailyBatchData, date);
+            }
 
             console.log(`[SelfRole] ✅ 频道 ${channel.name} 的历史消息回溯统计完成。`);
             const successEmbed = new EmbedBuilder()

--- a/src/modules/selfRole/services/activityTracker.js
+++ b/src/modules/selfRole/services/activityTracker.js
@@ -1,6 +1,6 @@
 // src/modules/selfRole/services/activityTracker.js
 
-const { saveUserActivityBatch, getSelfRoleSettings, getAllSelfRoleSettings, saveSelfRoleSettings } = require('../../../core/utils/database');
+const { saveUserActivityBatch, saveDailyUserActivityBatch, getSelfRoleSettings, getAllSelfRoleSettings, saveSelfRoleSettings } = require('../../../core/utils/database');
 
 /**
  * 单个用户在某频道内的活跃度增量数据。
@@ -70,8 +70,14 @@ async function _writeCacheToDatabase() {
     console.log(`[SelfRole] 💾 开始将 ${Object.keys(cacheToWrite).length} 个服务器的活跃度增量数据写入数据库...`);
 
     try {
+        // 保存总体活跃度数据
         await saveUserActivityBatch(cacheToWrite);
-        
+
+        // 保存每日活跃度数据
+        // 使用 UTC 时间确保与历史数据回溯的日期计算一致
+        const today = new Date().toISOString().split('T')[0]; // YYYY-MM-DD 格式（UTC）
+        await saveDailyUserActivityBatch(cacheToWrite, today);
+
         // 批量更新所有涉及服务器的最后成功保存时间戳
         const guildIds = Object.keys(cacheToWrite);
         for (const guildId of guildIds) {
@@ -81,7 +87,7 @@ async function _writeCacheToDatabase() {
                 await saveSelfRoleSettings(guildId, settings);
             }
         }
-        
+
         console.log('[SelfRole] ✅ 活跃度数据成功写入数据库。');
     } catch (error) {
         console.error('[SelfRole] ❌ 写入活跃度数据到数据库时出错:', error);


### PR DESCRIPTION
为自助身份组模块添加了更精细的活跃度检查机制，支持基于每日发言数的持续活跃度评估。

主要功能：
- 新增每日活跃度数据表: 创建 'daily_user_activity' 表，按日期存储用户活跃度数据
- 活跃天数条件检查: 支持检查用户在指定频道中每日发言超过阈值的天数
- 管理界面同步扩展: 在管理面板中支持配置活跃天数阈值条件

修改内容：
- 扩展数据库结构、新增 getUserActiveDaysCount、saveDailyUserActivityBatch 等函数
- 修改活跃度追踪器，同时记录总体和每日活跃度数据