### PR TITLE
feat(contest/participantRole): 添加参赛者身份组管理功能，支持绑定、自动/手动发放与移除

### DIFF
--- a/src/core/events/interactionCreate.js
+++ b/src/core/events/interactionCreate.js
@@ -81,6 +81,15 @@ const {
     handleVoteComplete
 } = require('../../modules/election/components/anonymousVotingComponents');
 
+const {
+    toggleAutoGrant,
+    showUserList,
+    handleUserListPageNavigation,
+    confirmManualAction,
+    grantToAll,
+    listAllParticipants
+} = require('../../modules/contest/services/participantRoleService');
+
 async function interactionCreateHandler(interaction) {
     try {
         // 处理自动补全
@@ -458,6 +467,31 @@ async function interactionCreateHandler(interaction) {
                 await handleListRolesButton(interaction);
             } else if (interaction.customId.startsWith('admin_roles_page_')) {
                 await handleRoleListPageChange(interaction);
+            }
+
+            // 参赛者身份组管理按钮
+            if (interaction.customId.startsWith('role_manage_')) {
+                if (interaction.customId.includes('_toggle_auto_')) {
+                    await toggleAutoGrant(interaction);
+                } else if (interaction.customId.includes('_grant_list_')) {
+                    await showUserList(interaction, 'grant');
+                } else if (interaction.customId.includes('_revoke_list_')) {
+                    await showUserList(interaction, 'revoke');
+                } else if (interaction.customId.includes('_grant_all_')) {
+                    await grantToAll(interaction);
+                } else if (interaction.customId.includes('_list_all_')) {
+                    await listAllParticipants(interaction);
+                }
+            } else if (interaction.customId.startsWith('role_page_')) {
+                const mode = interaction.customId.includes('_grant_') ? 'grant' : 'revoke';
+                await handleUserListPageNavigation(interaction, mode);
+            } else if (interaction.customId.startsWith('role_confirm_')) {
+                // 确认按钮需要等待用户从SelectMenu选择，所以这里的处理方式不同
+                // 注意：confirmManualAction 的逻辑已调整为在 service 中处理 awaitMessageComponent
+                const mode = interaction.customId.includes('_grant_') ? 'grant' : 'revoke';
+                await confirmManualAction(interaction, mode);
+            } else if (interaction.customId === 'role_cancel_op') {
+                await interaction.update({ content: '✅ 操作已取消。', embeds: [], components: [] });
             }
             
             return;

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -71,6 +71,8 @@ const manageAllowedForumsCommand = require('../modules/contest/commands/manageAl
 const manageExternalServersCommand = require('../modules/contest/commands/manageExternalServers');
 const cacheStats = require('../modules/contest/commands/cacheStats');
 const regenerateContestMessagesCommand = require('../modules/contest/commands/regenerateContestMessages');
+const bindParticipantRoleCommand = require('../modules/contest/commands/bindParticipantRole');
+const manageParticipantRoleCommand = require('../modules/contest/commands/manageParticipantRole');
 
 // 自动清理系统命令
 const addBannedKeywordCommand = require('../modules/autoCleanup/commands/addBannedKeyword');
@@ -207,6 +209,8 @@ client.commands.set(manageAllowedForumsCommand.data.name, manageAllowedForumsCom
 client.commands.set(manageExternalServersCommand.data.name, manageExternalServersCommand);
 client.commands.set(cacheStats.data.name, cacheStats);
 client.commands.set(regenerateContestMessagesCommand.data.name, regenerateContestMessagesCommand);
+client.commands.set(bindParticipantRoleCommand.data.name, bindParticipantRoleCommand);
+client.commands.set(manageParticipantRoleCommand.data.name, manageParticipantRoleCommand);
 
 // 自动清理系统命令
 client.commands.set(addBannedKeywordCommand.data.name, addBannedKeywordCommand);

--- a/src/modules/contest/commands/bindParticipantRole.js
+++ b/src/modules/contest/commands/bindParticipantRole.js
@@ -1,0 +1,47 @@
+﻿// src/modules/contest/commands/bindParticipantRole.js
+const { SlashCommandBuilder, MessageFlags } = require('discord.js');
+const { getContestChannel } = require('../utils/contestDatabase');
+const { checkContestManagePermission, getManagePermissionDeniedMessage } = require('../utils/contestPermissions');
+const { bindParticipantRole } = require('../services/participantRoleService');
+
+const data = new SlashCommandBuilder()
+    .setName('绑定比赛身份组')
+    .setDescription('为当前比赛绑定一个参赛者专属的装饰身份组')
+    .addRoleOption(option =>
+        option.setName('身份组')
+            .setDescription('要绑定的装饰性身份组（必须没有任何权限）')
+            .setRequired(true));
+
+async function execute(interaction) {
+    await interaction.deferReply({ ephemeral: true });
+
+    // 1. 检查是否在赛事频道中
+    const contestChannelData = await getContestChannel(interaction.channel.id);
+    if (!contestChannelData) {
+        return interaction.editReply({
+            content: '❌ 此指令只能在赛事频道中使用。',
+        });
+    }
+
+    // 2. 检查权限
+    const hasPermission = checkContestManagePermission(interaction.member, contestChannelData);
+    if (!hasPermission) {
+        return interaction.editReply({
+            content: getManagePermissionDeniedMessage(),
+        });
+    }
+
+    const role = interaction.options.getRole('身份组');
+
+    try {
+        await bindParticipantRole(interaction, role);
+    } catch (error) {
+        console.error('Error binding participant role:', error);
+        await interaction.editReply({ content: '❌ 绑定身份组时发生未知错误。' });
+    }
+}
+
+module.exports = {
+    data,
+    execute,
+};

--- a/src/modules/contest/commands/bindParticipantRole.js
+++ b/src/modules/contest/commands/bindParticipantRole.js
@@ -5,7 +5,7 @@ const { checkContestManagePermission, getManagePermissionDeniedMessage } = requi
 const { bindParticipantRole } = require('../services/participantRoleService');
 
 const data = new SlashCommandBuilder()
-    .setName('绑定比赛身份组')
+    .setName('赛事-绑定比赛身份组')
     .setDescription('为当前比赛绑定一个参赛者专属的装饰身份组')
     .addRoleOption(option =>
         option.setName('身份组')

--- a/src/modules/contest/commands/manageParticipantRole.js
+++ b/src/modules/contest/commands/manageParticipantRole.js
@@ -5,7 +5,7 @@ const { checkContestManagePermission, getManagePermissionDeniedMessage } = requi
 const { openRoleManagementPanel } = require('../services/participantRoleService');
 
 const data = new SlashCommandBuilder()
-    .setName('管理比赛身份组')
+    .setName('赛事-管理比赛身份组')
     .setDescription('打开参赛者身份组的管理面板');
 
 async function execute(interaction) {

--- a/src/modules/contest/commands/manageParticipantRole.js
+++ b/src/modules/contest/commands/manageParticipantRole.js
@@ -1,0 +1,41 @@
+﻿// src/modules/contest/commands/manageParticipantRole.js
+const { SlashCommandBuilder, MessageFlags } = require('discord.js');
+const { getContestChannel } = require('../utils/contestDatabase');
+const { checkContestManagePermission, getManagePermissionDeniedMessage } = require('../utils/contestPermissions');
+const { openRoleManagementPanel } = require('../services/participantRoleService');
+
+const data = new SlashCommandBuilder()
+    .setName('管理比赛身份组')
+    .setDescription('打开参赛者身份组的管理面板');
+
+async function execute(interaction) {
+    await interaction.deferReply({ ephemeral: true });
+
+    // 1. 检查是否在赛事频道中
+    const contestChannelData = await getContestChannel(interaction.channel.id);
+    if (!contestChannelData) {
+        return interaction.editReply({
+            content: '❌ 此指令只能在赛事频道中使用。',
+        });
+    }
+
+    // 2. 检查权限
+    const hasPermission = checkContestManagePermission(interaction.member, contestChannelData);
+    if (!hasPermission) {
+        return interaction.editReply({
+            content: getManagePermissionDeniedMessage(),
+        });
+    }
+
+    try {
+        await openRoleManagementPanel(interaction);
+    } catch (error) {
+        console.error('Error opening role management panel:', error);
+        await interaction.editReply({ content: '❌ 打开管理面板时发生未知错误。' });
+    }
+}
+
+module.exports = {
+    data,
+    execute,
+};

--- a/src/modules/contest/services/participantRoleService.js
+++ b/src/modules/contest/services/participantRoleService.js
@@ -1,0 +1,422 @@
+﻿// src/modules/contest/services/participantRoleService.js
+const { EmbedBuilder, ActionRowBuilder, ButtonBuilder, ButtonStyle, StringSelectMenuBuilder, ComponentType } = require('discord.js');
+const {
+    getContestChannel,
+    updateContestChannel,
+    getSubmissionsByChannel
+} = require('../utils/contestDatabase');
+const { preprocessSubmissions, paginateData } = require('../utils/dataProcessor');
+const { isRoleDecorative } = require('../utils/contestPermissions');
+
+const ITEMS_PER_PAGE = 10; // 身份组管理面板中每页显示的用户数
+
+/**
+ * 绑定参赛者身份组到比赛
+ * @param {import('discord.js').Interaction} interaction
+ * @param {import('discord.js').Role} role
+ */
+async function bindParticipantRole(interaction, role) {
+    const contestChannelData = await getContestChannel(interaction.channel.id);
+
+    // 1. 检查身份组是否为纯装饰性
+    if (!isRoleDecorative(role)) {
+        return interaction.editReply({
+            content: `❌ **身份组权限错误**\n\n身份组 \`${role.name}\` 包含权限，不能用作参赛者装饰身份组。\n\n请选择一个**没有任何权限**的身份组以确保安全。`
+        });
+    }
+
+    // 2. 检查机器人身份组层级
+    if (interaction.guild.members.me.roles.highest.position <= role.position) {
+        return interaction.editReply({
+            content: `❌ **身份组层级错误**\n\n我的身份组层级低于或等于 \`${role.name}\`，无法管理此身份组。\n\n请在服务器设置中将我的身份组拖到 \`${role.name}\` 之上。`
+        });
+    }
+
+    // 3. 更新数据库
+    await updateContestChannel(interaction.channel.id, {
+        participantRoleId: role.id,
+        autoGrantRole: contestChannelData.autoGrantRole || false // 保留现有的自动发放设置
+    });
+
+    await interaction.editReply({
+        content: `✅ **绑定成功！**\n\n已将身份组 **${role}** 绑定到本次比赛。\n\n现在您可以使用 \`/管理比赛身份组\` 命令来管理身份组的发放。`
+    });
+}
+
+/**
+ * 打开身份组管理面板
+ * @param {import('discord.js').Interaction} interaction
+ */
+async function openRoleManagementPanel(interaction) {
+    const contestChannelData = await getContestChannel(interaction.channel.id);
+
+    if (!contestChannelData || !contestChannelData.participantRoleId) {
+        return interaction.editReply({
+            content: '❌ 此比赛尚未绑定参赛者身份组。请先使用 `/绑定比赛身份组` 命令进行绑定。'
+        });
+    }
+
+    const role = await interaction.guild.roles.fetch(contestChannelData.participantRoleId).catch(() => null);
+    if (!role) {
+        return interaction.editReply({
+            content: '❌ 绑定的身份组似乎已被删除，请重新绑定一个新的身份组。'
+        });
+    }
+
+    const { embed, components } = buildManagementPanel(contestChannelData, role);
+    await interaction.editReply({ embeds: [embed], components: components });
+}
+
+/**
+ * 构建管理面板
+ * @param {object} contestChannelData
+ * @param {import('discord.js').Role} role
+ */
+function buildManagementPanel(contestChannelData, role) {
+    const autoGrantEnabled = contestChannelData.autoGrantRole || false;
+
+    const embed = new EmbedBuilder()
+        .setTitle('🏆 参赛者身份组管理面板')
+        .setDescription(`管理比赛的专属身份组的发放和移除。\n\n**当前绑定身份组：** ${role} (\`${role.id}\`)`)
+        .setColor(autoGrantEnabled ? '#4CAF50' : '#F44336')
+        .addFields({
+            name: '自动发放模式',
+            value: autoGrantEnabled ? '🟢 **已启用** (新投稿者将自动获得身份组)' : '🔴 **已禁用** (需要手动发放)',
+        })
+        .setFooter({ text: '请使用下方按钮进行操作' });
+
+    const components = [
+        new ActionRowBuilder().addComponents(
+            new ButtonBuilder()
+                .setCustomId(`role_manage_grant_list_${role.id}`)
+                .setLabel('手动发放')
+                .setStyle(ButtonStyle.Success),
+            new ButtonBuilder()
+                .setCustomId(`role_manage_revoke_list_${role.id}`)
+                .setLabel('手动移除')
+                .setStyle(ButtonStyle.Danger),
+            new ButtonBuilder()
+                .setCustomId(`role_manage_toggle_auto_${role.id}`)
+                .setLabel(autoGrantEnabled ? '禁用自动发放' : '启用自动发放')
+                .setStyle(ButtonStyle.Secondary)
+        ),
+        new ActionRowBuilder().addComponents(
+            new ButtonBuilder()
+                .setCustomId(`role_manage_grant_all_${role.id}`)
+                .setLabel('发放给所有参赛者')
+                .setStyle(ButtonStyle.Primary),
+            new ButtonBuilder()
+                .setCustomId(`role_manage_list_all_${role.id}`)
+                .setLabel('公开所有参赛者名单')
+                .setStyle(ButtonStyle.Secondary)
+        )
+    ];
+    return { embed, components };
+}
+
+/**
+ * 切换自动发放模式
+ * @param {import('discord.js').Interaction} interaction
+ */
+async function toggleAutoGrant(interaction) {
+    await interaction.deferUpdate();
+    const contestChannelData = await getContestChannel(interaction.channel.id);
+    const role = await interaction.guild.roles.fetch(contestChannelData.participantRoleId);
+
+    const newAutoGrantState = !contestChannelData.autoGrantRole;
+    await updateContestChannel(interaction.channel.id, { autoGrantRole: newAutoGrantState });
+
+    // 重新获取数据以构建新面板
+    const updatedData = await getContestChannel(interaction.channel.id);
+    const { embed, components } = buildManagementPanel(updatedData, role);
+    await interaction.editReply({ embeds: [embed], components: components });
+}
+
+/**
+ * 获取所有参赛者成员对象
+ * @param {import('discord.js').Guild} guild
+ * @param {string} contestChannelId
+ * @returns {Promise<Array<import('discord.js').GuildMember>>}
+ */
+async function getParticipantMembers(guild, contestChannelId) {
+    const submissions = await getSubmissionsByChannel(contestChannelId);
+    if (!submissions || submissions.length === 0) return [];
+
+    const validSubmissions = preprocessSubmissions(submissions);
+    const submitterIds = [...new Set(validSubmissions.map(s => s.submitterId))];
+
+    const members = [];
+    for (const id of submitterIds) {
+        const member = await guild.members.fetch(id).catch(() => null);
+        if (member) members.push(member);
+    }
+    return members;
+}
+
+/**
+ * 显示用户列表用于手动操作（发放/移除）
+ * @param {import('discord.js').Interaction} interaction
+ * @param {'grant'|'revoke'} mode
+ */
+async function showUserList(interaction, mode) {
+    await interaction.deferReply({ ephemeral: true });
+
+    const contestChannelData = await getContestChannel(interaction.channel.id);
+    const role = await interaction.guild.roles.fetch(contestChannelData.participantRoleId);
+
+    const allParticipants = await getParticipantMembers(interaction.guild, interaction.channel.id);
+    if (allParticipants.length === 0) {
+        return interaction.editReply({ content: '🤔 没有任何有效的参赛者。' });
+    }
+
+    let targetUsers;
+    if (mode === 'grant') {
+        targetUsers = allParticipants.filter(m => !m.roles.cache.has(role.id));
+    } else { // revoke
+        targetUsers = allParticipants.filter(m => m.roles.cache.has(role.id));
+    }
+
+    if (targetUsers.length === 0) {
+        const message = mode === 'grant'
+            ? '✅ 所有参赛者都已拥有该身份组。'
+            : '✅ 没有任何参赛者拥有该身份组。';
+        return interaction.editReply({ content: message });
+    }
+
+    // 分页处理
+    const pagination = paginateData(targetUsers, 1, ITEMS_PER_PAGE);
+    const { embed, components } = buildUserListPage(pagination, role, mode);
+
+    await interaction.editReply({ embeds: [embed], components: components });
+}
+
+/**
+ * 构建用户列表分页视图
+ * @param {object} pagination
+ * @param {import('discord.js').Role} role
+ * @param {'grant'|'revoke'} mode
+ */
+function buildUserListPage(pagination, role, mode) {
+    const { pageData, currentPage, totalPages } = pagination;
+    const title = mode === 'grant' ? '手动发放身份组' : '手动移除身份组';
+
+    const embed = new EmbedBuilder()
+        .setTitle(title)
+        .setDescription(pageData.map((member, i) => `${((currentPage-1)*ITEMS_PER_PAGE)+i+1}. ${member.user.tag} (${member.id})`).join('\n'))
+        .setColor(mode === 'grant' ? ButtonStyle.Success : ButtonStyle.Danger)
+        .setFooter({ text: `第 ${currentPage} / ${totalPages} 页` });
+
+    const selectMenu = new StringSelectMenuBuilder()
+        .setCustomId(`role_select_users_${mode}_${role.id}`)
+        .setPlaceholder('选择要操作的用户...')
+        .setMinValues(1)
+        .setMaxValues(Math.min(pageData.length, 25))
+        .addOptions(pageData.map(member => ({
+            label: member.user.tag.substring(0, 100),
+            value: member.id
+        })));
+
+    const components = [
+        new ActionRowBuilder().addComponents(selectMenu),
+        new ActionRowBuilder().addComponents(
+            new ButtonBuilder().setCustomId(`role_page_prev_${mode}_${role.id}_${currentPage}`).setLabel('◀️ 上一页').setStyle(ButtonStyle.Primary).setDisabled(currentPage <= 1),
+            new ButtonBuilder().setCustomId(`role_page_next_${mode}_${role.id}_${currentPage}`).setLabel('下一页 ▶️').setStyle(ButtonStyle.Primary).setDisabled(currentPage >= totalPages)
+        ),
+        new ActionRowBuilder().addComponents(
+            new ButtonBuilder().setCustomId(`role_confirm_${mode}_${role.id}`).setLabel(mode === 'grant' ? '确认发放' : '确认移除').setStyle(mode === 'grant' ? ButtonStyle.Success : ButtonStyle.Danger),
+            new ButtonBuilder().setCustomId('role_cancel_op').setLabel('取消').setStyle(ButtonStyle.Secondary)
+        )
+    ];
+
+    return { embed, components };
+}
+
+/**
+ * 处理用户列表分页
+ * @param {import('discord.js').Interaction} interaction
+ * @param {'grant'|'revoke'} mode
+ */
+async function handleUserListPageNavigation(interaction, mode) {
+    await interaction.deferUpdate();
+    const parts = interaction.customId.split('_');
+    const roleId = parts[parts.length - 2];
+    const currentPage = parseInt(parts[parts.length - 1]);
+    const direction = parts[2]; // prev or next
+
+    const newPage = direction === 'next' ? currentPage + 1 : currentPage - 1;
+
+    const role = await interaction.guild.roles.fetch(roleId);
+    const allParticipants = await getParticipantMembers(interaction.guild, interaction.channel.id);
+
+    let targetUsers;
+    if (mode === 'grant') {
+        targetUsers = allParticipants.filter(m => !m.roles.cache.has(role.id));
+    } else {
+        targetUsers = allParticipants.filter(m => m.roles.cache.has(role.id));
+    }
+
+    const pagination = paginateData(targetUsers, newPage, ITEMS_PER_PAGE);
+    const { embed, components } = buildUserListPage(pagination, role, mode);
+    await interaction.editReply({ embeds: [embed], components: components });
+}
+
+/**
+ * 确认手动操作（发放/移除）
+ * @param {import('discord.js').Interaction} interaction
+ * @param {'grant'|'revoke'} mode
+ */
+async function confirmManualAction(interaction, mode) {
+    await interaction.deferUpdate();
+    const roleId = interaction.customId.split('_').pop();
+    const role = await interaction.guild.roles.fetch(roleId);
+
+    // 从前一个交互（SelectMenu）中获取选择的用户
+    const message = interaction.message;
+    const selectInteraction = await message.awaitMessageComponent({
+        filter: i => i.user.id === interaction.user.id && i.isStringSelectMenu(),
+        componentType: ComponentType.StringSelect,
+        time: 60000 // 60秒超时
+    }).catch(() => null);
+
+    if (!selectInteraction) {
+        return interaction.followUp({ content: '❌ 操作超时，请重新选择用户。', ephemeral: true });
+    }
+
+    const userIds = selectInteraction.values;
+    await selectInteraction.deferUpdate();
+
+    let successCount = 0;
+    let failCount = 0;
+
+    for (const userId of userIds) {
+        const member = await interaction.guild.members.fetch(userId).catch(() => null);
+        if (member) {
+            try {
+                if (mode === 'grant') {
+                    await member.roles.add(role);
+                } else {
+                    await member.roles.remove(role);
+                }
+                successCount++;
+            } catch (e) {
+                console.error(`Failed to ${mode} role for ${member.user.tag}:`, e);
+                failCount++;
+            }
+        } else {
+            failCount++;
+        }
+    }
+
+    const actionText = mode === 'grant' ? '发放' : '移除';
+    await interaction.editReply({
+        content: `✅ **操作完成**\n成功${actionText} **${successCount}** 名用户。\n失败 **${failCount}** 名用户。`,
+        embeds: [],
+        components: []
+    });
+}
+
+
+/**
+ * 发放身份组给所有未拥有的参赛者
+ * @param {import('discord.js').Interaction} interaction
+ */
+async function grantToAll(interaction) {
+    await interaction.deferReply({ ephemeral: true });
+
+    const contestChannelData = await getContestChannel(interaction.channel.id);
+    const role = await interaction.guild.roles.fetch(contestChannelData.participantRoleId);
+
+    const allParticipants = await getParticipantMembers(interaction.guild, interaction.channel.id);
+    const usersToGrant = allParticipants.filter(m => !m.roles.cache.has(role.id));
+
+    if (usersToGrant.length === 0) {
+        return interaction.editReply({ content: '✅ 所有参赛者都已拥有该身份组。' });
+    }
+
+    let successCount = 0;
+    let failCount = 0;
+    for (const member of usersToGrant) {
+        try {
+            await member.roles.add(role);
+            successCount++;
+        } catch (e) {
+            failCount++;
+        }
+    }
+
+    await interaction.editReply({
+        content: `✅ **批量发放完成**\n成功发放给 **${successCount}** 名用户。\n失败 **${failCount}** 名用户。`
+    });
+}
+
+/**
+ * 公开发布所有参赛者名单
+ * @param {import('discord.js').Interaction} interaction
+ */
+async function listAllParticipants(interaction) {
+    await interaction.deferReply({ ephemeral: true });
+
+    const allParticipants = await getParticipantMembers(interaction.guild, interaction.channel.id);
+    if (allParticipants.length === 0) {
+        return interaction.editReply({ content: '🤔 没有任何有效的参赛者。' });
+    }
+
+    const userList = allParticipants.map(m => m.user.tag).join('\n');
+
+    const embed = new EmbedBuilder()
+        .setTitle(`🏆 ${interaction.channel.name} - 参赛者名单`)
+        .setDescription(userList)
+        .setColor('#87CEEB')
+        .setTimestamp();
+
+    // 发送公开消息，但不提及任何人
+    await interaction.channel.send({
+        embeds: [embed],
+        allowed_mentions: { parse: [] } // 禁用所有提及
+    });
+
+    await interaction.editReply({ content: '✅ 已在当前频道发布参赛者名单。' });
+}
+
+
+/**
+ * 在投稿时自动发放身份组（如果已启用）
+ * @param {import('discord.js').GuildMember} member - 投稿者成员对象
+ * @param {string} contestChannelId - 比赛频道ID
+ */
+async function grantRoleOnSubmission(member, contestChannelId) {
+    try {
+        const contestChannelData = await getContestChannel(contestChannelId);
+        if (!contestChannelData || !contestChannelData.autoGrantRole || !contestChannelData.participantRoleId) {
+            return; // 未开启或未设置，直接返回
+        }
+
+        const role = await member.guild.roles.fetch(contestChannelData.participantRoleId).catch(() => null);
+        if (!role || member.roles.cache.has(role.id)) {
+            return; // 身份组不存在或用户已拥有，直接返回
+        }
+
+        if (!isRoleDecorative(role) || member.guild.members.me.roles.highest.position <= role.position) {
+            console.warn(`[AutoGrant] Skipped granting role ${role.name} due to permission or hierarchy issues.`);
+            return; // 安全检查失败
+        }
+
+        await member.roles.add(role);
+        console.log(`[AutoGrant] Successfully granted role ${role.name} to ${member.user.tag}.`);
+    } catch (error) {
+        console.error(`[AutoGrant] Failed to grant role for contest ${contestChannelId} to ${member.user.tag}:`, error);
+    }
+}
+
+
+module.exports = {
+    bindParticipantRole,
+    openRoleManagementPanel,
+    toggleAutoGrant,
+    showUserList,
+    handleUserListPageNavigation,
+    confirmManualAction,
+    grantToAll,
+    listAllParticipants,
+    grantRoleOnSubmission
+};

--- a/src/modules/contest/services/participantRoleService.js
+++ b/src/modules/contest/services/participantRoleService.js
@@ -350,10 +350,11 @@ async function grantToAll(interaction) {
 }
 
 /**
- * 公开发布所有参赛者名单
+ * 私密地列出所有参赛者名单
  * @param {import('discord.js').Interaction} interaction
  */
 async function listAllParticipants(interaction) {
+    //  deferReply 必须是 ephemeral
     await interaction.deferReply({ ephemeral: true });
 
     const allParticipants = await getParticipantMembers(interaction.guild, interaction.channel.id);
@@ -361,21 +362,37 @@ async function listAllParticipants(interaction) {
         return interaction.editReply({ content: '🤔 没有任何有效的参赛者。' });
     }
 
-    const userList = allParticipants.map(m => m.user.tag).join('\n');
+    // 生成包含用户tag、ID和提及的详细列表
+    const userListString = allParticipants
+        .map((member, index) => `${index + 1}. ${member.user.tag} (${member.id})`)
+        .join('\n');
 
-    const embed = new EmbedBuilder()
-        .setTitle(`🏆 ${interaction.channel.name} - 参赛者名单`)
-        .setDescription(userList)
-        .setColor('#87CEEB')
-        .setTimestamp();
+    // 检查列表字符串长度
+    // Discord Embed description 上限是 4096，私密消息内容上限是 2000，我们取一个保守值
+    if (userListString.length < 1900) {
+        // 如果名单不长，直接用 Embed 发送
+        const embed = new EmbedBuilder()
+            .setTitle(`🏆 ${interaction.channel.name} - 参赛者名单 (私密)`)
+            .setDescription(userListString)
+            .setColor('#87CEEB')
+            .setFooter({ text: `共 ${allParticipants.length} 人 | 此消息仅您可见` })
+            .setTimestamp();
 
-    // 发送公开消息，但不提及任何人
-    await interaction.channel.send({
-        embeds: [embed],
-        allowed_mentions: { parse: [] } // 禁用所有提及
-    });
+        await interaction.editReply({ embeds: [embed] });
 
-    await interaction.editReply({ content: '✅ 已在当前频道发布参赛者名单。' });
+    } else {
+        // 如果名单太长，生成一个 txt 文件发送
+        const fileBuffer = Buffer.from(userListString, 'utf-8');
+        const attachment = {
+            attachment: fileBuffer,
+            name: `participants-${interaction.channel.id}.txt`
+        };
+
+        await interaction.editReply({
+            content: `✅ 参赛者名单过长（共 ${allParticipants.length} 人），已为您生成文本文件。此消息仅您可见。`,
+            files: [attachment]
+        });
+    }
 }
 
 

--- a/src/modules/contest/services/submissionService.js
+++ b/src/modules/contest/services/submissionService.js
@@ -9,6 +9,7 @@ const {
 } = require('../utils/contestDatabase');
 const { validateSubmissionLink, checkDuplicateSubmission } = require('./linkParser');
 const { displayService } = require('./displayService');
+const {grantRoleOnSubmission} = require("./participantRoleService");
 
 async function processContestSubmission(interaction) {
     try {
@@ -116,6 +117,11 @@ async function processContestSubmission(interaction) {
             submissions: updatedSubmissions,
             totalSubmissions: updatedSubmissions.length
         });
+
+        // 自动发放身份组
+        if (interaction.member) {
+            await grantRoleOnSubmission(interaction.member, contestChannelId);
+        }
         
         // 更新作品展示
         await updateSubmissionDisplay(interaction.client, contestChannelData);

--- a/src/modules/contest/utils/contestPermissions.js
+++ b/src/modules/contest/utils/contestPermissions.js
@@ -124,11 +124,22 @@ function getManagePermissionDeniedMessage() {
     return `❌ **权限不足**\n\n您没有权限管理此赛事频道。只有赛事申请人和管理员可以管理赛事。`;
 }
 
+/**
+ * 检查身份组是否为纯装饰性（无任何权限）
+ * @param {import('discord.js').Role} role - 要检查的身份组对象
+ * @returns {boolean}
+ */
+function isRoleDecorative(role) {
+    // BigInt 0n 代表没有任何权限位被设置
+    return role.permissions.bitfield === 0n;
+}
+
 module.exports = {
     checkContestApplicationPermission,
     checkContestReviewPermission,
     checkContestManagePermission,
     getApplicationPermissionDeniedMessage,
     getReviewPermissionDeniedMessage,
-    getManagePermissionDeniedMessage
+    getManagePermissionDeniedMessage,
+    isRoleDecorative,
 };


### PR DESCRIPTION
### feat(contest/participantRole): 添加参赛者身份组管理功能，支持绑定、自动/手动发放与移除

**类型**: 功能

#### 描述

本次提交为赛事模块引入了一套完整的参赛者身份组管理系统。该功能允许赛事管理员为一个比赛绑定一个专属的、纯装饰性的身份组，并通过一个功能丰富的交互式面板来管理该身份组的发放与移除，从而提升参赛者的荣誉感和社区的互动性。

#### 主要变更

- **新增核心命令**
  - **`/赛事-绑定比赛身份组`**: 用于将一个服务器内的身份组与当前赛事频道绑定。这是使用所有后续功能的前提。
  - **`/赛事-管理比赛身份组`**: 打开一个交互式的管理面板，集中进行所有与参赛者身份组相关的操作。

- **交互式管理面板**
  - 提供了一个包含多个按钮的控制中心，用于管理身份组。
  - 支持 **启用/禁用自动发放** 模式。
  - 提供 **手动发放** 和 **手动移除** 的入口，支持分页和多选操作。
  - 集成 **一键为所有参赛者发放** 和 **私密查看完整参赛者名单** 的便捷功能。

- **自动身份组发放**
  - 当“自动发放”模式启用时，任何用户在比赛中成功提交第一个作品后，系统将自动为其授予绑定的参赛者身份组。

- **强大的手动管理能力**
  - 管理员可以随时手动为部分或全部参赛者发放或移除身份组。
  - 用户选择界面经过精心设计，支持分页浏览，并允许一次性选择多个用户进行批量操作，极大提高了管理效率。

- **安全的权限与层级校验**
  - **装饰性身份组检查**: 强制要求绑定的身份组必须是“纯装饰性”的（即不包含任何权限），从根本上杜绝了潜在的安全风险。
  - **机器人层级检查**: 在执行操作前，系统会校验机器人的身份组层级是否高于要操作的身份组，确保其拥有足够的权限进行管理，并提供清晰的错误提示。

- **优化的名单展示**
  - “公开所有参赛者名单”功能实际上会以**私密消息**的形式将名单发送给操作者。
  - 当参赛者数量过多导致名单超长时，系统会自动生成一个 `.txt` 文本文件发送，避免了 Discord 消息长度限制的问题。