### PR TITLE
fix(contest/role): 修复身份组管理权限并优化批量发放功能

### DIFF
--- a/src/core/events/interactionCreate.js
+++ b/src/core/events/interactionCreate.js
@@ -86,7 +86,7 @@ const {
     showUserList,
     handleUserListPageNavigation,
     confirmManualAction,
-    grantToAll,
+    showBulkGrantGuide,
     listAllParticipants
 } = require('../../modules/contest/services/participantRoleService');
 
@@ -477,8 +477,8 @@ async function interactionCreateHandler(interaction) {
                     await showUserList(interaction, 'grant');
                 } else if (interaction.customId.includes('_revoke_list_')) {
                     await showUserList(interaction, 'revoke');
-                } else if (interaction.customId.includes('_grant_all_')) {
-                    await grantToAll(interaction);
+                } else if (interaction.customId.includes('_bulk_grant_guide_')) {
+                    await showBulkGrantGuide(interaction);
                 } else if (interaction.customId.includes('_list_all_')) {
                     await listAllParticipants(interaction);
                 }

--- a/src/modules/contest/commands/bindParticipantRole.js
+++ b/src/modules/contest/commands/bindParticipantRole.js
@@ -1,7 +1,7 @@
 ﻿// src/modules/contest/commands/bindParticipantRole.js
 const { SlashCommandBuilder, MessageFlags } = require('discord.js');
 const { getContestChannel } = require('../utils/contestDatabase');
-const { checkContestManagePermission, getManagePermissionDeniedMessage } = require('../utils/contestPermissions');
+const { checkContestRoleBindingPermission, getManagePermissionDeniedMessage } = require('../utils/contestPermissions');
 const { bindParticipantRole } = require('../services/participantRoleService');
 
 const data = new SlashCommandBuilder()
@@ -24,7 +24,7 @@ async function execute(interaction) {
     }
 
     // 2. 检查权限
-    const hasPermission = checkContestManagePermission(interaction.member, contestChannelData);
+    const hasPermission = checkContestRoleBindingPermission(interaction.member, contestChannelData);
     if (!hasPermission) {
         return interaction.editReply({
             content: getManagePermissionDeniedMessage(),

--- a/src/modules/contest/commands/manageParticipantRole.js
+++ b/src/modules/contest/commands/manageParticipantRole.js
@@ -1,7 +1,7 @@
 ﻿// src/modules/contest/commands/manageParticipantRole.js
 const { SlashCommandBuilder, MessageFlags } = require('discord.js');
-const { getContestChannel } = require('../utils/contestDatabase');
-const { checkContestManagePermission, getManagePermissionDeniedMessage } = require('../utils/contestPermissions');
+const { getContestChannel, getContestSettings} = require('../utils/contestDatabase');
+const { checkContestRoleManagePermission, getManagePermissionDeniedMessage } = require('../utils/contestPermissions');
 const { openRoleManagementPanel } = require('../services/participantRoleService');
 
 const data = new SlashCommandBuilder()
@@ -20,7 +20,8 @@ async function execute(interaction) {
     }
 
     // 2. 检查权限
-    const hasPermission = checkContestManagePermission(interaction.member, contestChannelData);
+    const contestSettings = await getContestSettings(interaction.guild.id);
+    const hasPermission = checkContestRoleManagePermission(interaction.member, contestChannelData, contestSettings);
     if (!hasPermission) {
         return interaction.editReply({
             content: getManagePermissionDeniedMessage(),

--- a/src/modules/contest/services/participantRoleService.js
+++ b/src/modules/contest/services/participantRoleService.js
@@ -102,12 +102,12 @@ function buildManagementPanel(contestChannelData, role) {
         ),
         new ActionRowBuilder().addComponents(
             new ButtonBuilder()
-                .setCustomId(`role_manage_grant_all_${role.id}`)
-                .setLabel('发放给所有参赛者')
-                .setStyle(ButtonStyle.Primary),
+                .setCustomId(`role_manage_bulk_grant_guide_${role.id}`) // 更改 customId
+                .setLabel('批量发放指南') // 更改标签
+                .setStyle(ButtonStyle.Primary), // 样式可以保持 Primary 或改为 Secondary
             new ButtonBuilder()
                 .setCustomId(`role_manage_list_all_${role.id}`)
-                .setLabel('公开所有参赛者名单')
+                .setLabel('导出参赛者名单')
                 .setStyle(ButtonStyle.Secondary)
         )
     ];
@@ -317,36 +317,42 @@ async function confirmManualAction(interaction, mode) {
 
 
 /**
- * 发放身份组给所有未拥有的参赛者
+ * 显示批量发放身份组的指南
  * @param {import('discord.js').Interaction} interaction
  */
-async function grantToAll(interaction) {
+async function showBulkGrantGuide(interaction) {
     await interaction.deferReply({ ephemeral: true });
 
-    const contestChannelData = await getContestChannel(interaction.channel.id);
-    const role = await interaction.guild.roles.fetch(contestChannelData.participantRoleId);
+    const embed = new EmbedBuilder()
+        .setTitle('🏆 批量发放身份组指南')
+        .setColor('#5865F2') // Discord 蓝色
+        .setDescription(
+            "为了防止误操作，我们移除了“一键发放”功能。您可以通过以下两种推荐的方法来安全地批量发放身份组：\n---"
+        )
+        .addFields(
+            {
+                name: '方法一：使用本机器人的手动发放功能',
+                value:
+                    "1. 在管理面板上，点击 **`手动发放`** 按钮。\n" +
+                    "2. 机器人会列出**第一页**尚未拥有身份组的参赛者。\n" +
+                    "3. 点击下方的**下拉菜单**，选择本页所有您想发放身份组的用户（可以多选）。\n" +
+                    "4. 点击 **`确认发放`** 按钮。\n" +
+                    "5. **如果参与者多于一页**，请点击 **`下一页`** 按钮，然后重复第 3 和第 4 步，直到完成所有页面的发放。\n\n" +
+                    "**优点**：安全可控，无需任何额外权限或机器人。"
+            },
+            {
+                name: '方法二：使用专业的管理机器人（推荐）',
+                value:
+                    "如果参赛人数非常多，手动分页会很繁琐。更高效的方法是：\n\n" +
+                    "1. 在管理面板上，点击 **`导出参赛者名单`** 按钮，获取所有参赛者的用户ID。\n" +
+                    "2. 复制这些用户ID。\n" +
+                    "3. 使用服务器中其他管理机器人的批量添加身份组命令。\n" +
+                    "**优点**：效率最高，尤其适合参赛人数众多的情况。"
+            }
+        )
+        .setFooter({ text: '这是一个操作指南，点击此处的按钮不会执行任何实际操作。' });
 
-    const allParticipants = await getParticipantMembers(interaction.guild, interaction.channel.id);
-    const usersToGrant = allParticipants.filter(m => !m.roles.cache.has(role.id));
-
-    if (usersToGrant.length === 0) {
-        return interaction.editReply({ content: '✅ 所有参赛者都已拥有该身份组。' });
-    }
-
-    let successCount = 0;
-    let failCount = 0;
-    for (const member of usersToGrant) {
-        try {
-            await member.roles.add(role);
-            successCount++;
-        } catch (e) {
-            failCount++;
-        }
-    }
-
-    await interaction.editReply({
-        content: `✅ **批量发放完成**\n成功发放给 **${successCount}** 名用户。\n失败 **${failCount}** 名用户。`
-    });
+    await interaction.editReply({ embeds: [embed] });
 }
 
 /**
@@ -433,7 +439,7 @@ module.exports = {
     showUserList,
     handleUserListPageNavigation,
     confirmManualAction,
-    grantToAll,
+    showBulkGrantGuide,
     listAllParticipants,
     grantRoleOnSubmission
 };


### PR DESCRIPTION
**变更内容 (What changed?)**

- 修正了 `赛事-绑定比赛身份组` 和 `赛事-管理比赛身份组` 命令的权限检查逻辑，确保赛事主办方和审核员都能正确使用。（主办方无法使用绑定比赛身份组）
- 移除了易于误操作的“一键发放给所有参赛者”功能，以防止意外授予身份组。
- 新增“批量发放指南”替代原功能，引导用户使用机器人内置的分页手动发放或配合其他专业机器人进行安全、高效的批量操作。

**影响范围 (Impact)**

-   影响 `contest` 模块下的身份组管理相关命令 (`赛事-绑定比赛身份组`, `赛事-管理比赛身份组`)。
-   更新了身份组管理面板的用户交互界面和逻辑。