### PR TITLE
自助身份组申请模块稳定性与数据库一致性修复

### DIFF
--- a/src/core/events/interactionCreate.js
+++ b/src/core/events/interactionCreate.js
@@ -620,7 +620,7 @@ async function interactionCreateHandler(interaction) {
                 await displayService.handleAwardModalSubmission(interaction);
             } else if (interaction.customId.startsWith('self_role_reason_reject_modal_')) {
                 await processRejectReasonModalSubmit(interaction);
-            } else if (interaction.customId.startsWith('self_role_reason_modal_')) {
+            } else if (interaction.customId.startsWith('self_role_reason_modal_') || interaction.customId.startsWith('self_role_reason_modal:')) {
                 // 自助身份组申请理由窗口提交
                 await handleReasonModalSubmit(interaction);
             } else if (interaction.customId.startsWith('sr_wiz:')) {

--- a/src/core/utils/database.js
+++ b/src/core/utils/database.js
@@ -114,6 +114,61 @@ function normalizeSelfRoleSettings(input) {
     return { ...settings, roles };
 }
 
+function dedupeActiveSelfRoleSystemAlertsForUniqueIndexes() {
+    const dedupeColumn = (columnName) => {
+        const groupStmt = selfRoleDb.prepare(`
+            SELECT ${columnName} AS dedupe_key, alert_type, COUNT(*) AS cnt
+            FROM sr_system_alerts
+            WHERE resolved_at IS NULL
+              AND ${columnName} IS NOT NULL
+            GROUP BY ${columnName}, alert_type
+            HAVING COUNT(*) > 1
+        `);
+        const listStmt = selfRoleDb.prepare(`
+            SELECT alert_id
+            FROM sr_system_alerts
+            WHERE resolved_at IS NULL
+              AND ${columnName} = ?
+              AND alert_type = ?
+            ORDER BY created_at DESC, alert_id DESC
+        `);
+        const resolveStmt = selfRoleDb.prepare(`
+            UPDATE sr_system_alerts
+            SET resolved_at = ?
+            WHERE alert_id = ? AND resolved_at IS NULL
+        `);
+
+        let groups = 0;
+        let resolved = 0;
+        const now = Date.now();
+        for (const group of groupStmt.all()) {
+            groups += 1;
+            const rows = listStmt.all(group.dedupe_key, group.alert_type);
+            // 保留最新一条 unresolved 告警，其余旧重复项自动标记为已解决，确保唯一索引可创建。
+            for (const row of rows.slice(1)) {
+                resolved += resolveStmt.run(now, row.alert_id)?.changes || 0;
+            }
+        }
+
+        return { groups, resolved };
+    };
+
+    const tx = selfRoleDb.transaction(() => {
+        const grant = dedupeColumn('grant_id');
+        const application = dedupeColumn('application_id');
+        return { grant, application };
+    });
+
+    const summary = tx();
+    const totalResolved = (summary.grant?.resolved || 0) + (summary.application?.resolved || 0);
+    if (totalResolved > 0) {
+        console.warn(
+            `[SelfRole] ⚠️ 已自动归并 ${totalResolved} 条历史重复未解决告警，以便创建 sr_system_alerts 去重唯一索引。`,
+        );
+    }
+    return summary;
+}
+
 function initializeSelfRoleDatabase() {
     // role_settings 表
     selfRoleDb.exec(`
@@ -355,6 +410,25 @@ function initializeSelfRoleDatabase() {
             ON sr_system_alerts (alert_type);
     `);
 
+    // 告警去重约束：同一 grant/application 的同类未解决告警只允许存在一条。
+    // SQLite 允许多个 NULL，因此分别为 grant 与 application 建部分唯一索引。
+    try {
+        dedupeActiveSelfRoleSystemAlertsForUniqueIndexes();
+        selfRoleDb.exec(`
+            CREATE UNIQUE INDEX IF NOT EXISTS uniq_sr_alerts_active_grant_type
+                ON sr_system_alerts (grant_id, alert_type)
+                WHERE resolved_at IS NULL AND grant_id IS NOT NULL;
+            CREATE UNIQUE INDEX IF NOT EXISTS uniq_sr_alerts_active_application_type
+                ON sr_system_alerts (application_id, alert_type)
+                WHERE resolved_at IS NULL AND application_id IS NOT NULL;
+        `);
+    } catch (idxErr) {
+        console.warn(
+            '[SelfRole] ⚠️ 创建 sr_system_alerts 去重唯一索引失败；告警仍可使用，但并发去重会退化为非唯一索引保护，请检查历史重复数据或 SQLite 版本。',
+            idxErr,
+        );
+    }
+
     console.log('[SelfRole] ✅ SQLite 数据库和表结构初始化完成。');
 }
 
@@ -583,6 +657,155 @@ async function saveDailyUserActivityBatch(batchData, date) {
 }
 
 /**
+ * 在同一个 SQLite 事务中同时保存总体活跃度与某日每日活跃度。
+ * 用于避免“总体表写入成功、每日表写入失败”后重试导致总体表重复累计。
+ * @param {object} batchData
+ * @param {string} date
+ * @returns {Promise<object>}
+ */
+async function saveUserActivityAndDailyBatch(batchData, date) {
+    const userStmt = selfRoleDb.prepare(`
+        INSERT INTO user_activity (guild_id, channel_id, user_id, message_count, mentioned_count, mentioning_count)
+        VALUES (?, ?, ?, ?, ?, ?)
+        ON CONFLICT(guild_id, channel_id, user_id) DO UPDATE SET
+            message_count = user_activity.message_count + excluded.message_count,
+            mentioned_count = user_activity.mentioned_count + excluded.mentioned_count,
+            mentioning_count = user_activity.mentioning_count + excluded.mentioning_count
+    `);
+
+    const dailyStmt = selfRoleDb.prepare(`
+        INSERT INTO daily_user_activity (guild_id, channel_id, user_id, date, message_count, mentioned_count, mentioning_count)
+        VALUES (?, ?, ?, ?, ?, ?, ?)
+        ON CONFLICT(guild_id, channel_id, user_id, date) DO UPDATE SET
+            message_count = daily_user_activity.message_count + excluded.message_count,
+            mentioned_count = daily_user_activity.mentioned_count + excluded.mentioned_count,
+            mentioning_count = daily_user_activity.mentioning_count + excluded.mentioning_count
+    `);
+
+    const transaction = selfRoleDb.transaction((guilds, targetDate) => {
+        for (const guildId in guilds) {
+            const channels = guilds[guildId];
+            for (const channelId in channels) {
+                const users = channels[channelId];
+                for (const userId in users) {
+                    const activity = users[userId];
+                    const messageCount = activity.messageCount || 0;
+                    const mentionedCount = activity.mentionedCount || 0;
+                    const mentioningCount = activity.mentioningCount || 0;
+
+                    userStmt.run(
+                        guildId,
+                        channelId,
+                        userId,
+                        messageCount,
+                        mentionedCount,
+                        mentioningCount,
+                    );
+
+                    dailyStmt.run(
+                        guildId,
+                        channelId,
+                        userId,
+                        targetDate,
+                        messageCount,
+                        mentionedCount,
+                        mentioningCount,
+                    );
+                }
+            }
+        }
+    });
+
+    try {
+        transaction(batchData, date);
+    } catch (err) {
+        console.error('[SelfRole] ❌ 批量保存总体/每日用户活跃度数据到 SQLite 时出错:', err);
+        throw err;
+    }
+
+    return batchData;
+}
+
+/**
+ * 在同一个 SQLite 事务中保存总体活跃度与按日期分组的每日活跃度。
+ * 用于离线补偿同步，避免总体表成功、某日 daily 失败后重试导致总体重复累计。
+ * @param {object} batchData
+ * @param {Record<string, object>} dailyBatchDataByDate
+ * @returns {Promise<object>}
+ */
+async function saveUserActivityAndDailyBatchByDate(batchData, dailyBatchDataByDate = {}) {
+    const userStmt = selfRoleDb.prepare(`
+        INSERT INTO user_activity (guild_id, channel_id, user_id, message_count, mentioned_count, mentioning_count)
+        VALUES (?, ?, ?, ?, ?, ?)
+        ON CONFLICT(guild_id, channel_id, user_id) DO UPDATE SET
+            message_count = user_activity.message_count + excluded.message_count,
+            mentioned_count = user_activity.mentioned_count + excluded.mentioned_count,
+            mentioning_count = user_activity.mentioning_count + excluded.mentioning_count
+    `);
+
+    const dailyStmt = selfRoleDb.prepare(`
+        INSERT INTO daily_user_activity (guild_id, channel_id, user_id, date, message_count, mentioned_count, mentioning_count)
+        VALUES (?, ?, ?, ?, ?, ?, ?)
+        ON CONFLICT(guild_id, channel_id, user_id, date) DO UPDATE SET
+            message_count = daily_user_activity.message_count + excluded.message_count,
+            mentioned_count = daily_user_activity.mentioned_count + excluded.mentioned_count,
+            mentioning_count = daily_user_activity.mentioning_count + excluded.mentioning_count
+    `);
+
+    const runActivityStmt = (stmt, guilds, targetDate = null) => {
+        for (const guildId in guilds) {
+            const channels = guilds[guildId];
+            for (const channelId in channels) {
+                const users = channels[channelId];
+                for (const userId in users) {
+                    const activity = users[userId];
+                    const messageCount = activity.messageCount || 0;
+                    const mentionedCount = activity.mentionedCount || 0;
+                    const mentioningCount = activity.mentioningCount || 0;
+
+                    if (targetDate == null) {
+                        stmt.run(
+                            guildId,
+                            channelId,
+                            userId,
+                            messageCount,
+                            mentionedCount,
+                            mentioningCount,
+                        );
+                    } else {
+                        stmt.run(
+                            guildId,
+                            channelId,
+                            userId,
+                            targetDate,
+                            messageCount,
+                            mentionedCount,
+                            mentioningCount,
+                        );
+                    }
+                }
+            }
+        }
+    };
+
+    const transaction = selfRoleDb.transaction((overall, dailyByDate) => {
+        runActivityStmt(userStmt, overall);
+        for (const [date, dailyBatchData] of Object.entries(dailyByDate || {})) {
+            runActivityStmt(dailyStmt, dailyBatchData, date);
+        }
+    });
+
+    try {
+        transaction(batchData || {}, dailyBatchDataByDate || {});
+    } catch (err) {
+        console.error('[SelfRole] ❌ 批量保存总体/多日每日用户活跃度数据到 SQLite 时出错:', err);
+        throw err;
+    }
+
+    return batchData;
+}
+
+/**
  * 获取用户在指定频道的每日活跃度数据。
  * @param {string} guildId - 服务器ID。
  * @param {string} channelId - 频道ID。
@@ -684,6 +907,60 @@ async function saveSelfRoleApplication(messageId, data) {
         JSON.stringify(data.rejectReasons || {})
     );
     return data;
+}
+
+/**
+ * 在申请仍为 pending 时原子写入投票数据。
+ * 用于避免某个审核操作已进入 processing 后，另一个并发投票把状态覆盖回 pending。
+ * @param {string} messageId
+ * @param {object} data
+ * @returns {Promise<boolean>} true 表示写入成功；false 表示申请已不再是 pending
+ */
+async function updatePendingSelfRoleApplicationVote(messageId, data) {
+    const stmt = selfRoleDb.prepare(`
+        UPDATE role_applications
+        SET approvers = ?,
+            rejecters = ?,
+            reason = ?,
+            reject_reasons = ?
+        WHERE message_id = ?
+          AND status = 'pending'
+    `);
+    const info = stmt.run(
+        JSON.stringify(data.approvers || []),
+        JSON.stringify(data.rejecters || []),
+        data.reason || null,
+        JSON.stringify(data.rejectReasons || {}),
+        messageId,
+    );
+    return (info?.changes || 0) > 0;
+}
+
+/**
+ * 原子地将 pending legacy 申请锁定为 processing，并同时写入最终投票快照。
+ * @param {string} messageId
+ * @param {object} data
+ * @returns {Promise<boolean>} true 表示成功取得终结锁；false 表示已被其他流程处理
+ */
+async function markSelfRoleApplicationProcessing(messageId, data) {
+    const stmt = selfRoleDb.prepare(`
+        UPDATE role_applications
+        SET status = 'processing',
+            approvers = ?,
+            rejecters = ?,
+            reason = ?,
+            reject_reasons = ?
+        WHERE message_id = ?
+          AND status = 'pending'
+    `);
+    const info = stmt.run(
+        JSON.stringify(data.approvers || []),
+        JSON.stringify(data.rejecters || []),
+        data.reason || null,
+        JSON.stringify(data.rejectReasons || {}),
+        messageId,
+    );
+    return (info?.changes || 0) > 0;
 }
 
 /**
@@ -1185,6 +1462,24 @@ async function listPendingSelfRoleApplicationsV2ByApplicant(guildId, applicantId
     `);
     const rows = stmt.all(guildId, applicantId);
     return Promise.all(rows.map(r => getSelfRoleApplicationV2(r.application_id)));
+}
+
+/**
+ * 原子地将 pending v2 申请标记为指定终态，并释放预留名额。
+ * @param {string} applicationId
+ * @param {string} status
+ * @param {string|null} resolutionReason
+ * @param {number} resolvedAt
+ * @returns {Promise<boolean>} true 表示成功终结；false 表示已不再是 pending
+ */
+async function resolvePendingSelfRoleApplicationV2(applicationId, status, resolutionReason = null, resolvedAt = Date.now()) {
+    const stmt = selfRoleDb.prepare(`
+        UPDATE sr_applications_v2
+        SET status = ?, resolved_at = ?, resolution_reason = ?, slot_reserved = 0, reserved_until = NULL
+        WHERE application_id = ? AND status = 'pending'
+    `);
+    const info = stmt.run(status, resolvedAt, resolutionReason, applicationId);
+    return (info?.changes || 0) > 0;
 }
 
 /**
@@ -1800,7 +2095,16 @@ async function createSelfRoleSystemAlert({
 }) {
     const alertId = randomUUID();
 
-    const stmt = selfRoleDb.prepare(`
+    const existingByGrant = grantId
+        ? await getActiveSelfRoleSystemAlertByGrantType(grantId, alertType).catch(() => null)
+        : null;
+    const existingByApplication = applicationId
+        ? await getActiveSelfRoleSystemAlertByApplicationType(applicationId, alertType).catch(() => null)
+        : null;
+    const existing = existingByGrant || existingByApplication;
+    if (existing) return { ...existing, deduped: true };
+
+    const insertStmt = selfRoleDb.prepare(`
         INSERT INTO sr_system_alerts (
             alert_id,
             guild_id,
@@ -1816,7 +2120,7 @@ async function createSelfRoleSystemAlert({
         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL)
     `);
 
-    stmt.run(
+    const args = [
         alertId,
         guildId,
         roleId,
@@ -1827,7 +2131,25 @@ async function createSelfRoleSystemAlert({
         String(message || ''),
         actionRequired ? String(actionRequired) : null,
         createdAt,
-    );
+    ];
+
+    try {
+        insertStmt.run(...args);
+    } catch (err) {
+        const code = err?.code || '';
+        const text = err?.message ? String(err.message) : String(err);
+        if (code === 'SQLITE_CONSTRAINT_UNIQUE' || text.includes('UNIQUE constraint failed')) {
+            const afterConflictByGrant = grantId
+                ? await getActiveSelfRoleSystemAlertByGrantType(grantId, alertType).catch(() => null)
+                : null;
+            const afterConflictByApplication = applicationId
+                ? await getActiveSelfRoleSystemAlertByApplicationType(applicationId, alertType).catch(() => null)
+                : null;
+            const afterConflict = afterConflictByGrant || afterConflictByApplication;
+            if (afterConflict) return { ...afterConflict, deduped: true };
+        }
+        throw err;
+    }
 
     return {
         alertId,
@@ -1841,6 +2163,7 @@ async function createSelfRoleSystemAlert({
         actionRequired: actionRequired ? String(actionRequired) : null,
         createdAt,
         resolvedAt: null,
+        deduped: false,
     };
 }
 
@@ -3413,11 +3736,15 @@ module.exports = {
     getUserActivity,
     saveUserActivityBatch,
     saveDailyUserActivityBatch,
+    saveUserActivityAndDailyBatch,
+    saveUserActivityAndDailyBatchByDate,
     getUserDailyActivity,
     getUserActiveDaysCount,
     getSelfRoleApplication,
     saveSelfRoleApplication,
     deleteSelfRoleApplication,
+    updatePendingSelfRoleApplicationVote,
+    markSelfRoleApplicationProcessing,
     // 根据申请人+身份组查询是否存在“待审核”申请，防止重复创建面板
     getPendingApplicationByApplicantRole,
     // 被拒绝后的冷却期管理
@@ -3441,6 +3768,7 @@ module.exports = {
     listPendingSelfRoleApplicationsV2ByApplicant,
     listLegacyPendingSelfRoleApplications,
     resolveSelfRoleApplicationV2,
+    resolvePendingSelfRoleApplicationV2,
     expirePendingSelfRoleApplicationsV2,
 
     // SelfRole grants

--- a/src/modules/selfRole/commands/checkActivity.js
+++ b/src/modules/selfRole/commands/checkActivity.js
@@ -1,7 +1,7 @@
 // src/modules/selfRole/commands/checkActivity.js
 
 const { SlashCommandBuilder, EmbedBuilder, ChannelType } = require('discord.js');
-const { getSelfRoleSettings, getUserActivity } = require('../../../core/utils/database');
+const { getSelfRoleSettings, getUserActivity, getUserActiveDaysCount } = require('../../../core/utils/database');
 
 module.exports = {
     data: new SlashCommandBuilder()
@@ -50,6 +50,28 @@ module.exports = {
             }
 
             const userActivity = await getUserActivity(guildId);
+
+            // 预先构建“频道 -> 该频道下配置了 activeDaysThreshold 的岗位配置”映射
+            // 说明：活跃天数需要“每日发言阈值”才能计算，因此这里按岗位配置中的 activeDaysThreshold 来展示。
+            const activeDaysRoleConfigsByChannel = {};
+            for (const role of settings.roles) {
+                const a = role?.conditions?.activity;
+                const dt = a?.activeDaysThreshold;
+                const channelId = a?.channelId;
+                if (!channelId || !dt) continue;
+                const dailyMessageThreshold = Number(dt.dailyMessageThreshold);
+                const requiredActiveDays = Number(dt.requiredActiveDays);
+                if (!Number.isFinite(dailyMessageThreshold) || dailyMessageThreshold <= 0) continue;
+                if (!Number.isFinite(requiredActiveDays) || requiredActiveDays <= 0) continue;
+
+                if (!activeDaysRoleConfigsByChannel[channelId]) activeDaysRoleConfigsByChannel[channelId] = [];
+                activeDaysRoleConfigsByChannel[channelId].push({
+                    roleId: role.roleId,
+                    roleLabel: role.label || role.roleId,
+                    dailyMessageThreshold,
+                    requiredActiveDays,
+                });
+            }
             
             const embed = new EmbedBuilder()
                 .setTitle('📈 您的活跃度统计')
@@ -63,6 +85,30 @@ module.exports = {
                 description += `> • **发言数**: ${activity.messageCount}\n`;
                 description += `> • **被提及数**: ${activity.mentionedCount}\n`;
                 description += `> • **主动提及数**: ${activity.mentioningCount}\n\n`;
+
+                // 活跃天数（仅当该频道下存在 activeDaysThreshold 配置时显示）
+                const roleCfgs = activeDaysRoleConfigsByChannel[specificChannel.id] || [];
+                if (roleCfgs.length > 0) {
+                    // 同一 dailyMessageThreshold 只计算一次，避免重复查询
+                    const cache = new Map();
+                    description += `该频道的 **活跃天数**（近90天，按UTC日切分；“每日发言≥阈值” 计为1天）：\n`;
+
+                    // 限制展示条数，避免 Embed 过长
+                    const MAX_LINES = 12;
+                    const showList = roleCfgs.slice(0, MAX_LINES);
+                    for (const cfg of showList) {
+                        if (!cache.has(cfg.dailyMessageThreshold)) {
+                            const c = await getUserActiveDaysCount(guildId, specificChannel.id, userId, cfg.dailyMessageThreshold).catch(() => 0);
+                            cache.set(cfg.dailyMessageThreshold, c);
+                        }
+                        const actual = cache.get(cfg.dailyMessageThreshold) ?? 0;
+                        description += `> • **${cfg.roleLabel}**: 每日发言≥${cfg.dailyMessageThreshold}，需 ${cfg.requiredActiveDays} 天；当前 ${actual} 天\n`;
+                    }
+                    if (roleCfgs.length > MAX_LINES) {
+                        description += `> ……（还有 ${roleCfgs.length - MAX_LINES} 个岗位配置未展示）\n`;
+                    }
+                    description += '\n';
+                }
             } else {
                 for (const channelId of channelIdsToCheck) {
                     const activity = userActivity[channelId]?.[userId] || { messageCount: 0, mentionedCount: 0, mentioningCount: 0 };
@@ -70,6 +116,27 @@ module.exports = {
                     description += `> • **发言数**: ${activity.messageCount}\n`;
                     description += `> • **被提及数**: ${activity.mentionedCount}\n`;
                     description += `> • **主动提及数**: ${activity.mentioningCount}\n\n`;
+
+                    const roleCfgs = activeDaysRoleConfigsByChannel[channelId] || [];
+                    if (roleCfgs.length > 0) {
+                        const cache = new Map();
+                        description += `该频道的 **活跃天数**（近90天，按UTC日切分；“每日发言≥阈值” 计为1天）：\n`;
+
+                        const MAX_LINES = 8;
+                        const showList = roleCfgs.slice(0, MAX_LINES);
+                        for (const cfg of showList) {
+                            if (!cache.has(cfg.dailyMessageThreshold)) {
+                                const c = await getUserActiveDaysCount(guildId, channelId, userId, cfg.dailyMessageThreshold).catch(() => 0);
+                                cache.set(cfg.dailyMessageThreshold, c);
+                            }
+                            const actual = cache.get(cfg.dailyMessageThreshold) ?? 0;
+                            description += `> • **${cfg.roleLabel}**: 每日发言≥${cfg.dailyMessageThreshold}，需 ${cfg.requiredActiveDays} 天；当前 ${actual} 天\n`;
+                        }
+                        if (roleCfgs.length > MAX_LINES) {
+                            description += `> ……（还有 ${roleCfgs.length - MAX_LINES} 个岗位配置未展示）\n`;
+                        }
+                        description += '\n';
+                    }
                 }
             }
 

--- a/src/modules/selfRole/commands/checkActivity.js
+++ b/src/modules/selfRole/commands/checkActivity.js
@@ -3,6 +3,12 @@
 const { SlashCommandBuilder, EmbedBuilder, ChannelType } = require('discord.js');
 const { getSelfRoleSettings, getUserActivity, getUserActiveDaysCount } = require('../../../core/utils/database');
 
+function trimEmbedDescription(text, maxLen = 3900) {
+    const raw = String(text || '');
+    if (raw.length <= maxLen) return raw;
+    return raw.slice(0, maxLen - 80).trimEnd() + '\n\n…（内容过长，已截断。请指定频道查询更详细数据。）';
+}
+
 module.exports = {
     data: new SlashCommandBuilder()
         .setName('自助身份组申请-查询我的活跃度')
@@ -144,7 +150,7 @@ module.exports = {
                 description = '暂无您的活跃度数据。';
             }
 
-            embed.setDescription(description);
+            embed.setDescription(trimEmbedDescription(description));
 
             await interaction.editReply({ embeds: [embed] });
             setTimeout(() => interaction.deleteReply().catch(() => {}), 60000);

--- a/src/modules/selfRole/commands/configureRoles.js
+++ b/src/modules/selfRole/commands/configureRoles.js
@@ -511,6 +511,7 @@ async function handleBasicConfig(interaction) {
       }
     }
     settings.roles[idx] = {
+      ...prev,
       roleId,
       label,
       description,

--- a/src/modules/selfRole/services/activityTracker.js
+++ b/src/modules/selfRole/services/activityTracker.js
@@ -1,6 +1,6 @@
 // src/modules/selfRole/services/activityTracker.js
 
-const { saveUserActivityBatch, saveDailyUserActivityBatch, getSelfRoleSettings, getAllSelfRoleSettings, saveSelfRoleSettings } = require('../../../core/utils/database');
+const { saveUserActivityAndDailyBatch, getSelfRoleSettings, getAllSelfRoleSettings, saveSelfRoleSettings } = require('../../../core/utils/database');
 
 /**
  * 单个用户在某频道内的活跃度增量数据。
@@ -50,6 +50,9 @@ let monitoredChannelsCache = {};
 // 定时器ID
 let saveInterval = null;
 
+// flush 互斥锁：避免定时写入与申请前立即写入重入，造成失败回滚后重复累计。
+let flushPromise = null;
+
 // 批量写入间隔（毫秒），例如5分钟
 const SAVE_INTERVAL_MS = 5 * 60 * 1000;
 
@@ -58,9 +61,40 @@ const SAVE_INTERVAL_MS = 5 * 60 * 1000;
  * @private
  */
 async function _writeCacheToDatabase() {
+    return flushActivityCacheToDatabase();
+}
+
+/**
+ * 立即将内存中的 selfRole 活跃度增量写入数据库。
+ * 申请前可调用它，避免刚达标的消息还停留在 5 分钟缓存窗口内。
+ * @returns {Promise<boolean>} true=执行了写入；false=缓存为空
+ */
+async function flushActivityCacheToDatabase() {
+    if (flushPromise) {
+        // 等待当前 flush 完成后，若期间产生了新的缓存增量，再串行补 flush 一次。
+        await flushPromise;
+        if (Object.keys(activityCache).length === 0) {
+            return false;
+        }
+        return flushActivityCacheToDatabase();
+    }
+
     // 如果缓存为空，则不执行任何操作
     if (Object.keys(activityCache).length === 0) {
-        return;
+        return false;
+    }
+
+    flushPromise = doFlushActivityCacheToDatabase()
+        .finally(() => {
+            flushPromise = null;
+        });
+
+    return await flushPromise;
+}
+
+async function doFlushActivityCacheToDatabase() {
+    if (Object.keys(activityCache).length === 0) {
+        return false;
     }
 
     // 复制并立即清空主缓存，以防在异步的数据库操作期间丢失新的消息数据
@@ -71,12 +105,9 @@ async function _writeCacheToDatabase() {
 
     try {
         // 保存总体活跃度数据
-        await saveUserActivityBatch(cacheToWrite);
-
-        // 保存每日活跃度数据
         // 使用 UTC 时间确保与历史数据回溯的日期计算一致
         const today = new Date().toISOString().split('T')[0]; // YYYY-MM-DD 格式（UTC）
-        await saveDailyUserActivityBatch(cacheToWrite, today);
+        await saveUserActivityAndDailyBatch(cacheToWrite, today);
 
         // 批量更新所有涉及服务器的最后成功保存时间戳
         const guildIds = Object.keys(cacheToWrite);
@@ -89,6 +120,7 @@ async function _writeCacheToDatabase() {
         }
 
         console.log('[SelfRole] ✅ 活跃度数据成功写入数据库。');
+        return true;
     } catch (error) {
         console.error('[SelfRole] ❌ 写入活跃度数据到数据库时出错:', error);
         // 如果写入失败，将数据合并回主缓存，以便下次重试
@@ -110,6 +142,7 @@ async function _writeCacheToDatabase() {
             }
         }
         console.log('[SelfRole] ⚠️ 数据已合并回缓存，将在下次定时任务时重试。');
+        throw error;
     }
 }
 
@@ -160,13 +193,13 @@ async function startActivityTracker() {
 /**
  * 停止定时器
  */
-function stopActivityTracker() {
+async function stopActivityTracker() {
     if (saveInterval) {
         clearInterval(saveInterval);
         saveInterval = null;
         console.log('[SelfRole] 🛑 活跃度追踪器已停止。');
         // 停止前最后执行一次写入，确保数据不丢失
-        _writeCacheToDatabase();
+        await _writeCacheToDatabase();
     }
 }
 
@@ -225,4 +258,5 @@ module.exports = {
     stopActivityTracker,
     handleMessage,
     updateMonitoredChannels, // 导出此函数，以便其他服务可以调用
+    flushActivityCacheToDatabase,
 };

--- a/src/modules/selfRole/services/adminPanelService.js
+++ b/src/modules/selfRole/services/adminPanelService.js
@@ -142,11 +142,15 @@ async function handleModalSubmit(interaction) {
             return;
         }
 
+        const previousRoleConfig = isEdit
+            ? (settings.roles.find(r => r.roleId === roleId) || null)
+            : null;
         const newRoleConfig = {
+            ...(previousRoleConfig || {}),
             roleId,
             label,
             description,
-            conditions: {},
+            conditions: { ...(previousRoleConfig?.conditions || {}) },
         };
 
         // 解析并验证条件
@@ -158,6 +162,8 @@ async function handleModalSubmit(interaction) {
                 return;
             }
             newRoleConfig.conditions.prerequisiteRoleId = prerequisiteRoleId;
+        } else {
+            delete newRoleConfig.conditions.prerequisiteRoleId;
         }
 
         if (activityString) {
@@ -198,6 +204,8 @@ async function handleModalSubmit(interaction) {
                     requiredActiveDays,
                 };
             }
+        } else {
+            delete newRoleConfig.conditions.activity;
         }
 
         if (approvalString) {
@@ -267,6 +275,8 @@ async function handleModalSubmit(interaction) {
             if (typeof cooldownDays === 'number' && cooldownDays > 0) {
                 newRoleConfig.conditions.approval.cooldownDays = cooldownDays;
             }
+        } else {
+            delete newRoleConfig.conditions.approval;
         }
         
         // 解析申请理由设置
@@ -310,6 +320,8 @@ async function handleModalSubmit(interaction) {
                 if (minLen !== null) newRoleConfig.conditions.reason.minLen = minLen;
                 if (maxLen !== null) newRoleConfig.conditions.reason.maxLen = maxLen;
             }
+        } else {
+            delete newRoleConfig.conditions.reason;
         }
 
         if (isEdit) {

--- a/src/modules/selfRole/services/alertReporter.js
+++ b/src/modules/selfRole/services/alertReporter.js
@@ -148,6 +148,10 @@ async function reportSelfRoleAlertOnce({
     return { alert: null, reported: false, reason: 'db_failed' };
   }
 
+  if (alert.deduped) {
+    return { alert, reported: false, reason: 'dedup_hit' };
+  }
+
   if (!channelId) {
     return { alert, reported: false, reason: 'no_channel' };
   }
@@ -188,7 +192,7 @@ async function reportSelfRoleAlertOnce({
   const finalMentionRoleId = mentionRoleId || getMentionRoleIdFromEnv();
   const content = finalMentionRoleId ? `<@&${finalMentionRoleId}> SelfRole 出现异常需要处理` : null;
 
-  await ch
+  const sent = await ch
     .send({
       content: content || undefined,
       embeds: [embed],
@@ -200,7 +204,12 @@ async function reportSelfRoleAlertOnce({
         `[SelfRole][Alert] ❌ 发送错误报告失败: guild=${guildId} channel=${channelId} alertType=${alertType} alertId=${alert.alertId}`,
         err,
       );
+      return null;
     });
+
+  if (!sent) {
+    return { alert, reported: false, reason: 'send_failed' };
+  }
 
   return { alert, reported: true, reason: 'ok' };
 }

--- a/src/modules/selfRole/services/applicationChecker.js
+++ b/src/modules/selfRole/services/applicationChecker.js
@@ -71,22 +71,25 @@ async function migrateLegacyPendingApplicationsToV2() {
 
         const applicationId = item.messageId; // 直接复用 messageId，便于排查
 
-        await saveSelfRoleApplicationV2(applicationId, {
-            guildId,
-            applicantId: item.applicantId,
-            roleId: item.roleId,
-            status: 'pending',
-            reason: item.reason || null,
-            reviewMessageId: item.messageId,
-            reviewChannelId: null,
-            slotReserved: true,
-            reservedUntil: now + DEFAULT_PENDING_EXPIRE_MS,
-            createdAt: now,
-            resolvedAt: null,
-            resolutionReason: null,
-        }).catch(() => {});
-
-        migrated++;
+        try {
+            await saveSelfRoleApplicationV2(applicationId, {
+                guildId,
+                applicantId: item.applicantId,
+                roleId: item.roleId,
+                status: 'pending',
+                reason: item.reason || null,
+                reviewMessageId: item.messageId,
+                reviewChannelId: null,
+                slotReserved: true,
+                reservedUntil: now + DEFAULT_PENDING_EXPIRE_MS,
+                createdAt: now,
+                resolvedAt: null,
+                resolutionReason: null,
+            });
+            migrated++;
+        } catch (err) {
+            console.error(`[SelfRole][AppChecker] ❌ legacy pending 申请迁移到 v2 失败: message=${item.messageId}`, err);
+        }
     }
 
     if (migrated > 0) {

--- a/src/modules/selfRole/services/approvalService.js
+++ b/src/modules/selfRole/services/approvalService.js
@@ -14,10 +14,13 @@ const {
     getSelfRoleApplication,
     saveSelfRoleApplication,
     deleteSelfRoleApplication,
+    updatePendingSelfRoleApplicationVote,
+    markSelfRoleApplicationProcessing,
     getSelfRoleSettings,
     setSelfRoleCooldown,
     getSelfRoleApplicationV2ByReviewMessageId,
     resolveSelfRoleApplicationV2,
+    resolvePendingSelfRoleApplicationV2,
     createSelfRoleGrant,
 } = require('../../../core/utils/database');
 
@@ -259,7 +262,12 @@ async function applyVote({ interaction, action, roleId, applicantId, voteMessage
         }
     }
 
-    await saveSelfRoleApplication(messageId, application);
+    const voteSaved = await updatePendingSelfRoleApplicationVote(messageId, application).catch(() => false);
+    if (!voteSaved) {
+        await interaction.editReply({ content: '❌ 该申请正在被其他审核操作处理，您的操作未被记录。' });
+        setTimeout(() => interaction.deleteReply().catch(() => {}), 60000);
+        return;
+    }
 
     // 3. 检查阈值
     const approvalCount = application.approvers.length;
@@ -297,20 +305,35 @@ async function updateApprovalPanel(voteMessage, application, roleConfig) {
     const originalEmbed = voteMessage.embeds[0];
     const { requiredApprovals, requiredRejections } = roleConfig.conditions.approval;
 
+    if (!originalEmbed) {
+        console.warn(`[SelfRole] ⚠️ 审核投票消息 ${voteMessage.id} 缺少 embed，仅跳过面板票数刷新。`);
+        return;
+    }
+
+    const originalFields = Array.isArray(originalEmbed.fields) ? originalEmbed.fields : [];
+    let hasApprovalField = false;
+    let hasRejectionField = false;
+
     const updatedEmbed = new EmbedBuilder(originalEmbed.data)
         .setFields(
-            ...originalEmbed.fields.map(field => {
+            ...originalFields.map(field => {
                 if (field.name === '支持票数') {
+                    hasApprovalField = true;
                     return { ...field, value: `${application.approvers.length} / ${requiredApprovals}` };
                 }
                 if (field.name === '反对票数') {
+                    hasRejectionField = true;
                     return { ...field, value: `${application.rejecters.length} / ${requiredRejections}` };
                 }
                 return field;
-            })
+            }),
+            ...(hasApprovalField ? [] : [{ name: '支持票数', value: `${application.approvers.length} / ${requiredApprovals}`, inline: true }]),
+            ...(hasRejectionField ? [] : [{ name: '反对票数', value: `${application.rejecters.length} / ${requiredRejections}`, inline: true }]),
         );
 
-    await voteMessage.edit({ embeds: [updatedEmbed] });
+    await voteMessage.edit({ embeds: [updatedEmbed] }).catch(err => {
+        console.error(`[SelfRole] ❌ 刷新审核投票面板失败: message=${voteMessage.id}`, err);
+    });
 }
 
 /**
@@ -351,9 +374,14 @@ function getDefaultDmTemplate(status) {
  * @param {object} roleConfig
  */
 async function finalizeApplication(interaction, voteMessage, application, finalStatus, roleConfig) {
-    // 竞态条件修复：立即更新数据库状态为 "processing" 防止重复处理
+    // 竞态条件修复：原子更新数据库状态为 "processing"，防止重复终结。
+    const locked = await markSelfRoleApplicationProcessing(voteMessage.id, application).catch(() => false);
+    if (!locked) {
+        await interaction.editReply({ content: '❌ 该申请已被其他审核操作处理，本次终结已跳过。' });
+        setTimeout(() => interaction.deleteReply().catch(() => {}), 60000);
+        return;
+    }
     application.status = 'processing';
-    await saveSelfRoleApplication(voteMessage.id, application);
 
     const applicant = await interaction.guild.members.fetch(application.applicantId).catch(() => null);
     const role = await interaction.guild.roles.fetch(application.roleId).catch(() => null);
@@ -380,6 +408,8 @@ async function finalizeApplication(interaction, voteMessage, application, finalS
     let dmMessage = '';
     // 发送给申请人的匿名拒绝理由
     let applicantRejectReasonChunks = [];
+    let grantOk = finalStatus !== 'approved';
+    let grantFailureReason = '';
 
     if (finalStatus === 'approved') {
         finalColor = 0x57F287; // Green
@@ -392,13 +422,10 @@ async function finalizeApplication(interaction, voteMessage, application, finalS
             try {
                 const bundleRoleIds = Array.isArray(roleConfig.bundleRoleIds) ? roleConfig.bundleRoleIds : [];
                 const roleIdsToAdd = [...new Set([role.id, ...bundleRoleIds])];
-                await applicant.roles.add(roleIdsToAdd);
+                const roleIdsToRollback = roleIdsToAdd.filter(rid => !applicant.roles.cache.has(rid));
+                let rollbackStatus = null;
 
-                const bundleSuffix = bundleRoleIds.length > 0 ? '（含配套身份组）' : '';
-                finalDescription += `\n\n用户 <@${applicant.id}> 已被授予 **${role.name}** 身份组${bundleSuffix}。`;
-                if (bundleRoleIds.length > 0) {
-                    finalDescription += `\n配套身份组：${bundleRoleIds.map(rid => `<@&${rid}>`).join(' ')}`;
-                }
+                await applicant.roles.add(roleIdsToAdd);
 
                 try {
                     const v2 = await getSelfRoleApplicationV2ByReviewMessageId(voteMessage.id);
@@ -411,15 +438,48 @@ async function finalizeApplication(interaction, voteMessage, application, finalS
                         bundleRoleIds,
                     });
                 } catch (dbErr) {
-                    console.error('[SelfRole] ❌ 写入 grant 记录失败（审核通过）:', dbErr);
+                    const dbErrText = dbErr?.message ? String(dbErr.message) : String(dbErr);
+                    console.error('[SelfRole] ❌ 写入 grant 记录失败（审核通过），准备回滚已发放身份组:', dbErr);
+
+                    try {
+                        if (roleIdsToRollback.length > 0) {
+                            await applicant.roles.remove(roleIdsToRollback);
+                        }
+                        rollbackStatus = 'rollback_ok';
+                    } catch (rollbackErr) {
+                        const rollbackErrText = rollbackErr?.message ? String(rollbackErr.message) : String(rollbackErr);
+                        rollbackStatus = 'rollback_failed';
+                        console.error('[SelfRole] ❌ grant 写入失败后回滚已发放身份组也失败:', rollbackErr);
+                        throw new Error(`grant_record_failed: ${dbErrText}; rollback_failed: ${rollbackErrText}`);
+                    }
+
+                    throw new Error(`grant_record_failed: ${dbErrText}; ${rollbackStatus}`);
                 }
+
+                const bundleSuffix = bundleRoleIds.length > 0 ? '（含配套身份组）' : '';
+                finalDescription += `\n\n用户 <@${applicant.id}> 已被授予 **${role.name}** 身份组${bundleSuffix}。`;
+                if (bundleRoleIds.length > 0) {
+                    finalDescription += `\n配套身份组：${bundleRoleIds.map(rid => `<@&${rid}>`).join(' ')}`;
+                }
+                grantOk = true;
             } catch (error) {
-                console.error(`[SelfRole] ❌ 授予身份组时出错: ${error}`);
-                finalDescription += `\n\n⚠️ 授予身份组时出错，请检查机器人权限。`;
-                dmMessage += `\n\n但机器人授予身份组时失败，请联系管理员。`;
+                console.error('[SelfRole] ❌ 授予身份组或写入 grant 记录时出错:', error);
+                grantFailureReason = error?.message ? String(error.message) : String(error);
+                finalStatusText = '⚠️ 通过但发放失败';
+                finalColor = 0xFEE75C;
+                finalDescription += `\n\n⚠️ 审核已达到通过阈值，但系统未能完成“身份组发放 + grant 记录写入”的完整流程。申请将标记为发放失败，不会结算为 approved。`;
+                if (grantFailureReason.includes('rollback_ok')) {
+                    finalDescription += `\n已自动回滚刚刚发放的身份组，避免服务器角色与数据库 grant 分叉。`;
+                } else if (grantFailureReason.includes('rollback_failed')) {
+                    finalDescription += `\n⚠️ 注意：身份组可能已发放但回滚失败，可能存在服务器角色与数据库 grant 不一致，请管理员立即核查。`;
+                }
+                dmMessage += `\n\n但机器人处理身份组发放时失败，请联系管理员。`;
             }
         } else {
-            finalDescription += `\n\n⚠️ 无法找到申请人或身份组，未能授予身份组。`;
+            grantFailureReason = !applicant ? 'applicant_missing' : 'role_missing';
+            finalStatusText = '⚠️ 通过但发放失败';
+            finalColor = 0xFEE75C;
+            finalDescription += `\n\n⚠️ 无法找到申请人或身份组，未能授予身份组。申请将标记为发放失败，不会结算为 approved。`;
         }
     } else {
         finalColor = 0xED4245; // Red
@@ -495,8 +555,12 @@ async function finalizeApplication(interaction, voteMessage, application, finalS
     const rejectersList = await getVoterList(interaction.guild, application.rejecters);
 
     const originalEmbed = voteMessage.embeds[0];
-    const applicantField = originalEmbed.fields.find(f => f.name === '申请人') || { name: '申请人', value: `<@${application.applicantId}>`, inline: true };
-    const roleField = originalEmbed.fields.find(f => f.name === '申请身份组') || { name: '申请身份组', value: `<@&${application.roleId}>`, inline: true };
+    if (!originalEmbed) {
+        console.warn(`[SelfRole] ⚠️ 审核终结时投票消息 ${voteMessage.id} 缺少 embed，将使用 fallback embed 继续结算。`);
+    }
+    const originalFields = Array.isArray(originalEmbed?.fields) ? originalEmbed.fields : [];
+    const applicantField = originalFields.find(f => f.name === '申请人') || { name: '申请人', value: `<@${application.applicantId}>`, inline: true };
+    const roleField = originalFields.find(f => f.name === '申请身份组') || { name: '申请身份组', value: `<@&${application.roleId}>`, inline: true };
 
     const finalFields = [
         applicantField,
@@ -507,31 +571,92 @@ async function finalizeApplication(interaction, voteMessage, application, finalS
     ];
 
     // 拒绝时附带“反对理由（可选）”摘要
-    if (finalStatus === 'rejected') {
+    if (finalStatus === 'rejected' || (finalStatus === 'approved' && !grantOk)) {
         const rejectReasonsSummary = formatRejectReasonsForEmbed(application.rejectReasons, application.rejecters);
         if (rejectReasonsSummary) {
             finalFields.push({ name: '📝 反对理由（可选）', value: rejectReasonsSummary, inline: false });
         }
     }
 
-    const finalEmbed = new EmbedBuilder(originalEmbed.data)
+    if (finalStatus === 'approved' && !grantOk) {
+        finalFields.push({
+            name: '⚠️ 发放失败原因',
+            value: grantFailureReason ? grantFailureReason.slice(0, 1000) : 'unknown_error',
+            inline: false,
+        });
+    }
+
+    const finalEmbed = originalEmbed
+        ? new EmbedBuilder(originalEmbed.data)
+        : new EmbedBuilder().setTitle('自助身份组申请审核结果').setTimestamp();
+
+    finalEmbed
         .setColor(finalColor)
         .setDescription(finalDescription)
         .setFields(...finalFields);
 
     const disabledRows = buildDisabledRows(voteMessage);
 
-    await voteMessage.edit({ embeds: [finalEmbed], components: disabledRows });
+    await voteMessage.edit({ embeds: [finalEmbed], components: disabledRows }).catch(err => {
+        console.error(`[SelfRole] ❌ 更新审核终结面板失败，将继续执行 DB 结算: message=${voteMessage.id}`, err);
+    });
+
+    const v2 = await getSelfRoleApplicationV2ByReviewMessageId(voteMessage.id).catch(() => null);
+
+    if (finalStatus === 'approved' && !grantOk) {
+        await reportSelfRoleAlertOnce({
+            client: interaction.client,
+            guildId: interaction.guild.id,
+            channelId: voteMessage.channel?.id,
+            roleId: application.roleId,
+            grantId: null,
+            applicationId: v2?.applicationId || voteMessage.id,
+            alertType: 'application_approved_grant_failed',
+            severity: 'high',
+            title: '⚠️ 审核通过但身份组发放失败',
+            message:
+                `申请已达到通过阈值，但无法向申请人 ${application.applicantId} 发放身份组。\n` +
+                `身份组：<@&${application.roleId}>\n` +
+                `错误：${grantFailureReason || 'unknown_error'}`,
+            actionRequired:
+                `请管理员检查机器人 Manage Roles 权限、角色层级、目标成员是否仍在服务器。\n` +
+                `系统已将申请标记为 grant_failed 并清理 legacy 投票锁，避免 processing/pending 卡单。\n` +
+                `如错误包含 rollback_failed，请立即核查申请人是否仍持有相关身份组；如需补发，请管理员手动授予并使用运维命令同步 grant。`,
+        }).catch(() => {});
+
+        try {
+            if (v2 && v2.status === 'pending') {
+                await resolvePendingSelfRoleApplicationV2(
+                    v2.applicationId,
+                    'grant_failed',
+                    'approved_but_grant_failed',
+                    Date.now(),
+                );
+            }
+        } catch (err) {
+            console.error('[SelfRole] ❌ 标记 v2 申请为 grant_failed 时出错:', err);
+        }
+
+        // legacy 表当前已被锁定为 processing；失败分支必须清理，避免后续无法撤回/无法重试的卡单。
+        await deleteSelfRoleApplication(voteMessage.id).catch(err => {
+            console.error('[SelfRole] ❌ 清理 grant_failed legacy 申请记录时出错:', err);
+        });
+
+        scheduleActiveUserSelfRolePanelsRefresh(interaction.client, interaction.guild.id, 'application_grant_failed');
+        await interaction.editReply({ content: '⚠️ 投票已达通过阈值，但身份组发放失败；申请已标记为 grant_failed 并上报告警。' });
+        setTimeout(() => interaction.deleteReply().catch(() => {}), 60000);
+        console.log(`[SelfRole] ⚠️ 申请 ${voteMessage.id} 通过但发放身份组失败，已标记为 grant_failed`);
+        return;
+    }
 
     await interaction.editReply({ content: '✅ 投票已结束，申请已处理。' });
     setTimeout(() => interaction.deleteReply().catch(() => {}), 60000);
     console.log(`[SelfRole] 🗳️ 申请 ${voteMessage.id} 已终结，状态: ${finalStatus}`);
 
-     // v2：终结申请并释放预留名额
+    // v2：终结申请并释放预留名额
     try {
-        const v2 = await getSelfRoleApplicationV2ByReviewMessageId(voteMessage.id);
         if (v2 && v2.status === 'pending') {
-            await resolveSelfRoleApplicationV2(v2.applicationId, finalStatus, finalStatus, Date.now());
+            await resolvePendingSelfRoleApplicationV2(v2.applicationId, finalStatus, finalStatus, Date.now());
         }
     } catch (err) {
         console.error('[SelfRole] ❌ 终结 v2 申请记录时出错:', err);

--- a/src/modules/selfRole/services/autoSyncService.js
+++ b/src/modules/selfRole/services/autoSyncService.js
@@ -1,5 +1,5 @@
 const { ChannelType } = require('discord.js');
-const { getAllSelfRoleSettings, saveUserActivityBatch, saveDailyUserActivityBatch } = require('../../../core/utils/database');
+const { getAllSelfRoleSettings, saveUserActivityAndDailyBatchByDate } = require('../../../core/utils/database');
 
 /**
  * @file autoSyncService.js
@@ -69,6 +69,7 @@ async function syncMissedActivity(client) {
     const allSettings = await getAllSelfRoleSettings();
 
     const batchData = {}; // 用于收集所有服务器的增量数据
+    const dailyBatchDataByDate = {}; // 按消息实际创建日期汇总每日活跃度
 
     for (const guildId in allSettings) {
         try {
@@ -112,6 +113,19 @@ async function syncMissedActivity(client) {
                     for (const message of missedMessages) {
                         if (message.author.bot) continue;
 
+                        const messageDate = new Date(message.createdTimestamp).toISOString().split('T')[0];
+                        if (!dailyBatchDataByDate[messageDate]) dailyBatchDataByDate[messageDate] = {};
+                        if (!dailyBatchDataByDate[messageDate][guildId]) dailyBatchDataByDate[messageDate][guildId] = {};
+                        if (!dailyBatchDataByDate[messageDate][guildId][channelId]) dailyBatchDataByDate[messageDate][guildId][channelId] = {};
+                        const dailyUsers = dailyBatchDataByDate[messageDate][guildId][channelId];
+
+                        const ensureDailyUser = (uid) => {
+                            if (!dailyUsers[uid]) {
+                                dailyUsers[uid] = { messageCount: 0, mentionedCount: 0, mentioningCount: 0 };
+                            }
+                            return dailyUsers[uid];
+                        };
+
                         const authorId = message.author.id;
                         if (!guildIncrements[channelId]) guildIncrements[channelId] = {};
                         if (!guildIncrements[channelId][authorId]) {
@@ -119,10 +133,12 @@ async function syncMissedActivity(client) {
                         }
                         
                         guildIncrements[channelId][authorId].messageCount++;
+                        ensureDailyUser(authorId).messageCount++;
 
                         const isMentioning = message.reference !== null || message.mentions.users.size > 0 || message.mentions.roles.size > 0;
                         if (isMentioning) {
                             guildIncrements[channelId][authorId].mentioningCount++;
+                            ensureDailyUser(authorId).mentioningCount++;
                         }
 
                         message.mentions.users.forEach(user => {
@@ -132,6 +148,7 @@ async function syncMissedActivity(client) {
                                 guildIncrements[channelId][mentionedId] = { messageCount: 0, mentionedCount: 0, mentioningCount: 0 };
                             }
                             guildIncrements[channelId][mentionedId].mentionedCount++;
+                            ensureDailyUser(mentionedId).mentionedCount++;
                         });
                     }
                 }
@@ -149,29 +166,7 @@ async function syncMissedActivity(client) {
     if (Object.keys(batchData).length > 0) {
         console.log(`[SelfRole-AutoSync] 💾 Writing batch data for ${Object.keys(batchData).length} guilds to the database...`);
         try {
-            // 保存总体活跃度数据
-            await saveUserActivityBatch(batchData);
-
-            // 按日期保存每日活跃度数据
-            // 需要按消息的创建日期分组保存
-            const dailyBatchData = {};
-            for (const guildId in batchData) {
-                const channels = batchData[guildId];
-                for (const channelId in channels) {
-                    const users = channels[channelId];
-                    for (const userId in users) {
-                        // 这里简化处理，将所有数据归到今天
-                        // 实际应用中可能需要更复杂的日期处理逻辑
-                        const today = new Date().toISOString().split('T')[0];
-                        if (!dailyBatchData[guildId]) dailyBatchData[guildId] = {};
-                        if (!dailyBatchData[guildId][channelId]) dailyBatchData[guildId][channelId] = {};
-                        dailyBatchData[guildId][channelId][userId] = users[userId];
-                    }
-                }
-            }
-
-            const today = new Date().toISOString().split('T')[0];
-            await saveDailyUserActivityBatch(dailyBatchData, today);
+            await saveUserActivityAndDailyBatchByDate(batchData, dailyBatchDataByDate);
 
             console.log('[SelfRole-AutoSync] ✅ Batch write (总体和每日数据) successful.');
         } catch (error) {

--- a/src/modules/selfRole/services/lifecycleScheduler.js
+++ b/src/modules/selfRole/services/lifecycleScheduler.js
@@ -107,7 +107,11 @@ async function ensureGrantSchedule(grant, roleConfig) {
     let forceRemoveAt = grant.forceRemoveAt;
     let changed = false;
 
-    if (nextInquiryAt == null && inquiryDays > 0) {
+    // nextInquiryAt === null has two meanings in persisted rows:
+    // 1) first-cycle grants created before schedule initialization;
+    // 2) intentionally no further inquiry before forceRemoveAt.
+    // Only initialize the first cycle when no inquiry has ever been sent.
+    if (nextInquiryAt == null && inquiryDays > 0 && grant.lastInquiryAt == null) {
         nextInquiryAt = grant.grantedAt + inquiryDays * DAY_MS;
         changed = true;
     }
@@ -310,9 +314,38 @@ async function processForceRemove(client, grant, roleConfig, scheduleInfo) {
     const roles = await listSelfRoleGrantRoles(grant.grantId);
     const roleIdsToRemove = roles.map(r => r.roleId);
 
-    await member.roles.remove(roleIdsToRemove).catch(err => {
+    let removeOk = false;
+    let removeErrText = '';
+    try {
+        if (roleIdsToRemove.length > 0) {
+            await member.roles.remove(roleIdsToRemove);
+        }
+        removeOk = true;
+    } catch (err) {
+        removeErrText = err?.message ? String(err.message) : String(err);
         console.error('[SelfRole][Lifecycle] ❌ 强制清退移除身份组失败:', err);
-    });
+    }
+
+    if (!removeOk) {
+        await setSelfRoleGrantManualAttentionRequired(grant.grantId, true).catch(() => {});
+        await reportSelfRoleAlertOnce({
+            client,
+            guildId: grant.guildId,
+            channelId: reportChannelId,
+            roleId: grant.primaryRoleId,
+            grantId: grant.grantId,
+            applicationId: grant.applicationId,
+            alertType: 'lifecycle_force_remove_role_remove_failed',
+            severity: 'high',
+            title: '⚠️ 强制清退失败：无法移除身份组',
+            message: `强制清退到期，但无法从用户 ${grant.userId} 移除身份组：${removeErrText || 'unknown_error'}`,
+            actionRequired:
+                `grant 已保持 active，避免名额统计与服务器真实角色不一致。\n` +
+                `请管理员检查机器人角色层级/权限，并手动移除：${roleIdsToRemove.map(rid => `<@&${rid}>`).join(' ') || `<@&${grant.primaryRoleId}>`}。\n` +
+                `处理完成后可使用 /自助身份组申请-运维 开除岗位成员 结束 grant。`,
+        }).catch(() => {});
+        return;
+    }
 
     await endSelfRoleGrant(grant.grantId, 'force_remove', now).catch(() => {});
     scheduleActiveUserSelfRolePanelsRefresh(client, grant.guildId, 'lifecycle_force_removed');
@@ -558,9 +591,39 @@ async function handleSelfRoleRenewalDecision(interaction) {
     const roles = await listSelfRoleGrantRoles(grant.grantId);
     const roleIdsToRemove = roles.map(r => r.roleId);
 
-    await member.roles.remove(roleIdsToRemove).catch(err => {
+    let removeOk = false;
+    let removeErrText = '';
+    try {
+        if (roleIdsToRemove.length > 0) {
+            await member.roles.remove(roleIdsToRemove);
+        }
+        removeOk = true;
+    } catch (err) {
+        removeErrText = err?.message ? String(err.message) : String(err);
         console.error('[SelfRole][Lifecycle] ❌ 用户选择退出时移除身份组失败:', err);
-    });
+    }
+
+    if (!removeOk) {
+        await setSelfRoleGrantManualAttentionRequired(grant.grantId, true).catch(() => {});
+        await reportSelfRoleAlertOnce({
+            client: interaction.client,
+            guildId: grant.guildId,
+            channelId: reportChannelId,
+            roleId: grant.primaryRoleId,
+            grantId: grant.grantId,
+            applicationId: grant.applicationId,
+            alertType: 'lifecycle_user_exit_role_remove_failed',
+            severity: 'high',
+            title: '⚠️ 用户退出失败：无法移除身份组',
+            message: `用户 ${grant.userId} 已选择退出，但机器人无法移除身份组：${removeErrText || 'unknown_error'}`,
+            actionRequired:
+                `grant 已保持 active，避免数据库显示已结束但服务器角色仍存在。\n` +
+                `请管理员检查机器人角色层级/权限，并手动移除：${roleIdsToRemove.map(rid => `<@&${rid}>`).join(' ') || `<@&${grant.primaryRoleId}>`}。\n` +
+                `处理完成后可使用 /自助身份组申请-运维 开除岗位成员 结束 grant。`,
+        }).catch(() => {});
+        await interaction.editReply({ content: '⚠️ 已收到你的退出选择，但机器人移除身份组失败；已通知管理员处理，grant 暂未结束。' });
+        return;
+    }
 
     await endSelfRoleGrant(grant.grantId, 'user_exit', now).catch(() => {});
 

--- a/src/modules/selfRole/services/selfRoleService.js
+++ b/src/modules/selfRole/services/selfRoleService.js
@@ -21,6 +21,8 @@ const {
 
 const { scheduleActiveUserSelfRolePanelsRefresh } = require('./panelService');
 const { checkExpiredSelfRoleApplications } = require('./applicationChecker');
+const { flushActivityCacheToDatabase } = require('./activityTracker');
+const { reportSelfRoleAlertOnce } = require('./alertReporter');
 
 const DEFAULT_PENDING_EXPIRE_MS = 7 * 24 * 60 * 60 * 1000;
 
@@ -31,6 +33,88 @@ function formatDateTime(ts) {
         return String(ts);
     }
 }
+
+function formatErrorText(error) {
+    return error?.message ? String(error.message) : String(error);
+}
+
+async function reportDirectGrantFailure({
+    client,
+    guildId,
+    channelId,
+    roleId,
+    userId,
+    roleIdsToRollback,
+    roleIdsToAdd,
+    reason,
+}) {
+    await reportSelfRoleAlertOnce({
+        client,
+        guildId,
+        channelId,
+        roleId,
+        grantId: null,
+        applicationId: `direct:${guildId}:${userId}:${roleId}`,
+        alertType: 'direct_grant_failed',
+        severity: reason.includes('rollback_failed') ? 'high' : 'medium',
+        title: '⚠️ 直授身份组失败',
+        message:
+            `用户 ${userId} 的直授流程未能完整完成。\n` +
+            `身份组：<@&${roleId}>\n` +
+            `错误：${reason || 'unknown_error'}`,
+        actionRequired:
+            `系统已尽量回滚本次新增的身份组，避免服务器角色与数据库 grant 分叉。\n` +
+            `本次计划发放：${roleIdsToAdd.map(rid => `<@&${rid}>`).join(' ') || `<@&${roleId}>`}\n` +
+            `本次可回滚新增：${roleIdsToRollback.map(rid => `<@&${rid}>`).join(' ') || '（无，本次未新增或无法判断）'}\n` +
+            `如错误包含 rollback_failed，请立即核查该用户是否仍持有已发放但未落库的身份组。`,
+    }).catch(() => {});
+}
+
+async function grantSelfRoleDirectly({ interaction, member, roleConfig, roleId, guildId }) {
+    const bundleRoleIds = Array.isArray(roleConfig.bundleRoleIds) ? roleConfig.bundleRoleIds : [];
+    const roleIdsToAdd = [...new Set([roleId, ...bundleRoleIds])];
+    const roleIdsToRollback = roleIdsToAdd.filter(rid => !member.roles.cache.has(rid));
+
+    await member.roles.add(roleIdsToAdd);
+
+    try {
+        await createSelfRoleGrant({
+            guildId,
+            userId: member.id,
+            primaryRoleId: roleId,
+            applicationId: null,
+            grantedAt: Date.now(),
+            bundleRoleIds,
+        });
+    } catch (dbErr) {
+        const dbErrText = formatErrorText(dbErr);
+        let failureReason = `grant_record_failed: ${dbErrText}`;
+        try {
+            if (roleIdsToRollback.length > 0) {
+                await member.roles.remove(roleIdsToRollback);
+            }
+            failureReason += '; rollback_ok';
+        } catch (rollbackErr) {
+            failureReason += `; rollback_failed: ${formatErrorText(rollbackErr)}`;
+        }
+
+        await reportDirectGrantFailure({
+            client: interaction.client,
+            guildId,
+            channelId: interaction.channel?.id,
+            roleId,
+            userId: member.id,
+            roleIdsToRollback,
+            roleIdsToAdd,
+            reason: failureReason,
+        });
+
+        throw new Error(failureReason);
+    }
+
+    return { bundleRoleIds, roleIdsToAdd };
+}
+
 
 /**
  * 处理用户点击“自助身份组申请”按钮的事件。
@@ -222,7 +306,8 @@ async function handleSelfRoleSelect(interaction) {
                 : '请说明申请该身份组的理由（可选）';
 
             const modal = new ModalBuilder()
-                .setCustomId(`self_role_reason_modal_${roleId}`)
+                // 追加来源 panelMessageId，用于 modal 提交时再次校验多面板可申请范围。
+                .setCustomId(`self_role_reason_modal:${roleId}:${panelMessageId || ''}`)
                 .setTitle(`申请理由: ${roleConfig.label}`);
 
             const reasonInput = new TextInputBuilder()
@@ -243,6 +328,9 @@ async function handleSelfRoleSelect(interaction) {
 
     // 过期清理可能包含 Discord API 编辑消息等操作，可能较慢；因此必须在 defer 之后执行。
     await checkExpiredSelfRoleApplications(interaction.client).catch(() => {});
+
+    // 申请前先刷入内存活跃度增量，避免刚达标的发言仍停留在 5 分钟缓存窗口内。
+    await flushActivityCacheToDatabase().catch(() => {});
 
     const userActivity = await getUserActivity(guildId);
 
@@ -347,30 +435,25 @@ async function handleSelfRoleSelect(interaction) {
             }
             // 如果资格预审通过且无需审核
             else {
-                try {
-                    const bundleRoleIds = Array.isArray(roleConfig.bundleRoleIds) ? roleConfig.bundleRoleIds : [];
-                    const roleIdsToAdd = [...new Set([roleId, ...bundleRoleIds])];
-                    await member.roles.add(roleIdsToAdd);
+                const existingV2 = await getPendingSelfRoleApplicationV2ByApplicantRole(guildId, member.id, roleId);
+                const existingLegacy = await getPendingApplicationByApplicantRole(member.id, roleId);
+                if (existingV2 || existingLegacy) {
+                    const expireText = existingV2?.reservedUntil
+                        ? `（将于 ${formatDateTime(existingV2.reservedUntil)} 自动过期）`
+                        : '';
+                    results.push(`⏳ **${roleConfig.label}**: 您仍有同一身份组的待审核申请${expireText}。为避免审核记录和直授状态冲突，请先使用 /自助身份组申请-撤回申请 撤回后再申请。`);
+                    continue;
+                }
 
-                    try {
-                        await createSelfRoleGrant({
-                            guildId,
-                            userId: member.id,
-                            primaryRoleId: roleId,
-                            applicationId: null,
-                            grantedAt: Date.now(),
-                            bundleRoleIds,
-                        });
-                    } catch (dbErr) {
-                        console.error('[SelfRole] ❌ 写入 grant 记录失败（直授）:', dbErr);
-                    }
+                try {
+                    const { bundleRoleIds } = await grantSelfRoleDirectly({ interaction, member, roleConfig, roleId, guildId });
 
                     const bundleSuffix = bundleRoleIds.length > 0 ? '（含配套身份组）' : '';
                     results.push(`✅ **${roleConfig.label}**: 成功获取！${bundleSuffix}`);
                     scheduleActiveUserSelfRolePanelsRefresh(interaction.client, guildId, 'direct_grant');
                 } catch (error) {
                     console.error(`[SelfRole] ❌ 授予身份组 ${roleConfig.label} 时出错:`, error);
-                    results.push(`❌ **${roleConfig.label}**: 授予失败，可能是机器人权限不足。`);
+                    results.push(`❌ **${roleConfig.label}**: 授予失败或 grant 记录写入失败，系统已尽量回滚本次新增身份组，请联系管理员确认。`);
                 }
             }
         } else {
@@ -588,11 +671,43 @@ async function handleReasonModalSubmit(interaction) {
 
     const guildId = interaction.guild.id;
     const member = interaction.member;
-    const customId = interaction.customId; // self_role_reason_modal_<roleId>
-    const roleId = customId.replace('self_role_reason_modal_', '');
+    const customId = String(interaction.customId || ''); // legacy: self_role_reason_modal_<roleId>; new: self_role_reason_modal:<roleId>:<panelMessageId>
+    let roleId = '';
+    let panelMessageId = null;
+    if (customId.startsWith('self_role_reason_modal:')) {
+        const payload = customId.slice('self_role_reason_modal:'.length);
+        const [rid, panelId] = payload.split(':');
+        roleId = rid || '';
+        panelMessageId = panelId || null;
+    } else {
+        roleId = customId.replace('self_role_reason_modal_', '');
+    }
+
+    if (!roleId) {
+        await interaction.editReply({ content: '❌ 无法解析申请身份组，请重新从申请面板发起。' });
+        setTimeout(() => interaction.deleteReply().catch(() => {}), 60000);
+        return;
+    }
+
+    if (panelMessageId) {
+        const panel = await getSelfRolePanel(panelMessageId).catch(() => null);
+        if (!panel || panel.panelType !== 'user' || !panel.isActive) {
+            await interaction.editReply({ content: '⚠️ 该申请面板已被停用或已过期，请重新从最新面板发起申请。' });
+            setTimeout(() => interaction.deleteReply().catch(() => {}), 60000);
+            return;
+        }
+        if (Array.isArray(panel.roleIds) && panel.roleIds.length > 0 && !panel.roleIds.includes(roleId)) {
+            await interaction.editReply({ content: '❌ 你申请的身份组不属于该面板允许申请的范围，请重新从对应面板发起申请。' });
+            setTimeout(() => interaction.deleteReply().catch(() => {}), 60000);
+            return;
+        }
+    }
 
     // 先做一次过期清理（避免“已过期但未清理”的 pending 卡住重复申请）
     await checkExpiredSelfRoleApplications(interaction.client).catch(() => {});
+
+    // modal 路径同样需要把最新消息增量落库后再做资格预审。
+    await flushActivityCacheToDatabase().catch(() => {});
 
     // 读取当前配置与活动数据
     const settings = await getSelfRoleSettings(guildId);
@@ -729,6 +844,17 @@ async function handleReasonModalSubmit(interaction) {
             await createApprovalPanel(interaction, roleConfig, sanitized || null);
             await interaction.editReply({ content: `⏳ **${roleConfig.label}**: 资格审查通过，已提交社区审核。` });
         } else {
+            const existingV2 = await getPendingSelfRoleApplicationV2ByApplicantRole(guildId, member.id, roleId);
+            const existingLegacy = await getPendingApplicationByApplicantRole(member.id, roleId);
+            if (existingV2 || existingLegacy) {
+                const expireText = existingV2?.reservedUntil
+                    ? `（将于 ${formatDateTime(existingV2.reservedUntil)} 自动过期）`
+                    : '';
+                await interaction.editReply({ content: `⏳ **${roleConfig.label}**: 您仍有同一身份组的待审核申请${expireText}。为避免审核记录和直授状态冲突，请先使用 /自助身份组申请-撤回申请 撤回后再申请。` });
+                setTimeout(() => interaction.deleteReply().catch(() => {}), 60000);
+                return;
+            }
+
             // 直授场景：名额检查（现任 + 待审核预留名额）
             const maxMembers = roleConfig?.conditions?.capacity?.maxMembers;
             const hasLimit = typeof maxMembers === 'number' && maxMembers > 0;
@@ -749,22 +875,7 @@ async function handleReasonModalSubmit(interaction) {
             }
 
             // 直授场景：授予身份组
-            const bundleRoleIds = Array.isArray(roleConfig.bundleRoleIds) ? roleConfig.bundleRoleIds : [];
-            const roleIdsToAdd = [...new Set([roleId, ...bundleRoleIds])];
-            await member.roles.add(roleIdsToAdd);
-
-            try {
-                await createSelfRoleGrant({
-                    guildId,
-                    userId: member.id,
-                    primaryRoleId: roleId,
-                    applicationId: null,
-                    grantedAt: Date.now(),
-                    bundleRoleIds,
-                });
-            } catch (dbErr) {
-                console.error('[SelfRole] ❌ 写入 grant 记录失败（直授）:', dbErr);
-            }
+            const { bundleRoleIds } = await grantSelfRoleDirectly({ interaction, member, roleConfig, roleId, guildId });
 
             const bundleSuffix = bundleRoleIds.length > 0 ? '（含配套身份组）' : '';
             await interaction.editReply({ content: `✅ **${roleConfig.label}**: 成功获取！${bundleSuffix}` });


### PR DESCRIPTION
这次主要是修复 SelfRole 模块里一些会导致状态不一致的问题，比如：

用户已经拿到 Discord 身份组，但数据库里没有对应 grant 记录；
数据库显示 grant 已结束，但用户实际还持有身份组；
留任询问可能重复发送；
审核消息被编辑/损坏后可能导致申请卡住；
系统告警可能重复，或者发送失败却被当成成功；
活跃度同步在部分失败后可能重复累计。
简单来说，这次 PR 的目标是：
让 SelfRole 在异常情况下更安全，不轻易把数据库和 Discord 真实状态弄不一致。

主要修复内容：
1. 修复留任询问重复发送
修复了 lifecycle 调度里 nextInquiryAt 被错误重新初始化的问题。
现在用户处理过留任询问后，不会因为下一轮调度又被重复私信。
正常的留任询问、强制轮换、强制清退逻辑仍然保留。

2. 修复身份组发放和 grant 写入不一致
审核通过和直授路径都做了加强：
只有 Discord 身份组发放成功，并且数据库 grant 写入成功，才算真正成功；
如果 grant 写入失败，会尝试回滚本次新增的身份组；
回滚时只移除“本次新增”的角色，不会误删用户原本已有的角色；
如果回滚也失败，会发系统告警，提醒管理员人工处理。

3. 修复移除身份组失败后错误结束 grant
之前某些场景下，如果机器人移除用户身份组失败，数据库仍可能把 grant 标记为 ended。
这会造成：
数据库：用户已经退出
Discord：用户其实还持有身份组
现在改为
移除成功才结束 grant；
移除失败则保持 grant active；
标记需要人工处理；
发送系统告警。

4. 修复审核消息异常导致卡单
如果审核消息的 embed 被管理员手动改坏、删除，之前可能导致 finalize 报错，然后申请卡在处理中。
现在增加了 fallback
embed 缺失时也能继续结算；
字段缺失时使用默认字段；
面板更新失败不会阻断数据库结算；
降低 pending / processing 卡单风险。

5. 修复系统告警去重和发送状态
改进了系统告警逻辑
同时支持按 grant 和 application 去重；
创建唯一索引前会先清理历史重复 unresolved alert；
如果频道发送失败，不再错误返回 reported: true；
避免“数据库有告警，但频道没通知，还以为成功”的情况。

6. 修复活跃度写入一致性
活跃度写入现在更安全
定时 flush 和申请前 flush 做了串行保护；
总体活跃度和每日活跃度使用同一个事务写入；
autoSync 离线补偿也改为单事务写入总体和多日每日数据；
避免部分写入成功后重试导致重复累计。

7. 改进 legacy 数据兼容
保留旧申请表兼容逻辑。
legacy pending 迁移到 v2 时，现在只有真正写入成功才计数，失败会明确打日志，避免误导排查。



other fixes：
配置保存不丢字段；
审核并发锁；
直授与 pending 申请冲突处理；
modal 来源校验；
离线活跃度日期修正；
申请前 flush 活跃度；
查询活跃度输出保护；
查询活跃度显示活跃天数；
老库 alert 重复数据迁移兼容；
验证和进度文档更新。