### PR TITLE
feat: 新增总结预设管理功能及默认逻辑优化

### DIFF
--- a/core/events/interactionCreate.js
+++ b/core/events/interactionCreate.js
@@ -1,0 +1,726 @@
+// src/core/events/interactionCreate.js
+const { PermissionFlagsBits, MessageFlags } = require('discord.js');
+const { createFormModal } = require('../../modules/proposal/components/formModal');
+const { createReviewModal } = require('../../modules/creatorReview/components/reviewModal');
+const { processFormSubmission } = require('../../modules/proposal/services/formService');
+const { processReviewSubmission } = require('../../modules/creatorReview/services/reviewService');
+const { processVote } = require('../../modules/proposal/services/voteTracker');
+// 法庭相关处理
+const { processCourtSupport } = require('../../modules/court/services/courtVoteTracker');
+const { processCourtVote } = require('../../modules/court/services/courtVotingSystem');
+// 自助管理相关处理
+const { processSelfModerationInteraction } = require('../../modules/selfModeration/services/moderationService');
+const { handleSelfRoleButton, handleSelfRoleSelect, handleReasonModalSubmit } = require('../../modules/selfRole/services/selfRoleService');
+const { processApprovalVote, showRejectReasonModal, processRejectReasonModalSubmit } = require('../../modules/selfRole/services/approvalService');
+const { handleSelfRoleRenewalDecision } = require('../../modules/selfRole/services/lifecycleScheduler');
+const { handleSelfRoleAlertResolveButton } = require('../../modules/selfRole/services/alertReporter');
+const {
+    handleSelfRoleConfigWizardButton,
+    handleSelfRoleConfigWizardSelect,
+    handleSelfRoleConfigWizardModal,
+} = require('../../modules/selfRole/services/configWizardService');
+const {
+    handleAddRoleButton,
+    handleRemoveRoleButton,
+    handleListRolesButton,
+    handleEditRoleButton,
+    handleRoleSelectForAdd,
+    handleRoleSelectForEdit,
+    handleModalSubmit,
+    handleRoleSelectForRemove,
+    handleRoleListPageChange
+} = require('../../modules/selfRole/services/adminPanelService');
+
+// 投票系统相关处理
+const { createVoteSetupModal, handleVoteSetupSubmit } = require('../../modules/voting/components/voteSetupModal');
+const { handleVoteButton } = require('../../modules/voting/components/voteButtons');
+const { handleNotificationButton } = require('../../modules/voting/components/notificationButtons');
+
+// 选举系统相关处理
+const {
+    handleRegistrationButton,
+    handleFirstChoiceSelection,
+    handleSecondChoiceSelection,
+    handleIntroductionModal,
+    handleEditRegistration,
+    handleWithdrawRegistration
+} = require('../../modules/election/components/registrationComponents');
+
+// 管理员编辑候选人相关处理
+const {
+    handleAdminStatusChange,
+    handleReasonModal,
+    handleAdminEditInfo
+} = require('../../modules/election/components/adminEditComponents');
+
+// 赛事系统相关处理
+const { createContestApplicationModal } = require('../../modules/contest/components/applicationModal');
+const { createSubmissionModal } = require('../../modules/contest/components/submissionModal');
+const { createConfirmChannelModal } = require('../../modules/contest/components/confirmChannelModal');
+const {
+    processContestApplication,
+    processEditApplication,
+    processEditApplicationSubmission
+} = require('../../modules/contest/services/applicationService');
+
+// 频道创建最终确认处理函数
+const { processChannelConfirmation } = require('../../modules/contest/services/channelCreationService');
+const { processContestSubmission } = require('../../modules/contest/services/submissionService');
+const { processCancelApplication } = require('../../modules/contest/services/reviewService');
+const { displayService } = require('../../modules/contest/services/displayService');
+const { getContestApplication, getContestSettings } = require('../../modules/contest/utils/contestDatabase');
+const { checkContestApplicationPermission, getApplicationPermissionDeniedMessage } = require('../../modules/contest/utils/contestPermissions');
+const { processSubmissionManagement, processSubmissionAction, processDeleteConfirmation, processRejectionModal } = require('../../modules/contest/services/submissionManagementService');
+const { createRejectionModal } = require('../../modules/contest/components/rejectionModal');
+
+// 议案编辑相关处理
+const { processEditProposal, processEditProposalSubmission } = require('../../modules/proposal/services/proposalEditService');
+
+const { checkFormPermission, getFormPermissionDeniedMessage } = require('../../core/utils/permissionManager');
+const { getFormPermissionSettings } = require('../../core/utils/database');
+
+// 频道总结预设交互处理
+const {
+  handlePresetButton,
+  handlePresetModal,
+} = require('../../modules/channelSummary/services/presetInteractionHandler');
+
+const INTERACTION_DEBUG_LOG = String(process.env.INTERACTION_DEBUG_LOG || '').toLowerCase() === 'true';
+
+const {
+    handleAnonymousVoteStart,
+    handleAnonymousVoteSelect,
+    handleAnonymousVoteConfirm,
+    handleAnonymousVoteCancel,
+    handleVotingPagination,
+    handleVoteComplete
+} = require('../../modules/election/components/anonymousVotingComponents');
+
+const {
+    toggleAutoGrant,
+    showUserList,
+    showBulkGrantGuide,
+    listAllParticipants
+} = require('../../modules/contest/services/participantRoleService');
+
+async function interactionCreateHandler(interaction) {
+    try {
+        if (INTERACTION_DEBUG_LOG) {
+            const gid = interaction.guild?.id || 'dm';
+            const uid = interaction.user?.id || 'unknown';
+            if (interaction.isChatInputCommand()) {
+                console.log(`[Interaction][cmd] ${interaction.commandName} guild=${gid} user=${uid}`);
+            } else if (interaction.isButton()) {
+                console.log(`[Interaction][button] ${interaction.customId} guild=${gid} user=${uid}`);
+            } else if (interaction.isStringSelectMenu()) {
+                console.log(`[Interaction][select] ${interaction.customId} guild=${gid} user=${uid}`);
+            } else if (interaction.isModalSubmit()) {
+                console.log(`[Interaction][modal] ${interaction.customId} guild=${gid} user=${uid}`);
+            }
+        }
+        // 处理自动补全
+        if (interaction.isAutocomplete()) {
+            const command = interaction.client.commands.get(interaction.commandName);
+            if (!command) return;
+
+            try {
+                await command.autocomplete(interaction);
+            } catch (error) {
+                console.error('自动补全时出错:', error);
+            }
+            return;
+        }
+
+        // 处理命令
+        if (interaction.isChatInputCommand()) {
+            const command = interaction.client.commands.get(interaction.commandName);
+            
+            if (!command) {
+                console.warn(`[Interaction] ⚠️ 未找到命令处理器: ${interaction.commandName} (guild=${interaction.guild?.id || 'dm'} user=${interaction.user?.id || 'unknown'})`);
+                // 避免“无反应”：给用户一个可操作的提示
+                if (!interaction.replied && !interaction.deferred) {
+                    await interaction.reply({
+                        content: '❌ 该命令在当前机器人版本中未加载或已被移除。\n\n可能原因：\n- 你看到的是旧的全局命令残留（建议测试环境设置 CLEAR_GLOBAL_COMMANDS=true 后重启一次）\n- 机器人刚重启但命令同步未完成（建议开启 STRICT_COMMAND_SYNC=true）\n\n请联系管理员检查启动日志并重新同步命令。',
+                        ephemeral: true,
+                    }).catch(() => {});
+                }
+                return;
+            }
+            
+            await command.execute(interaction);
+            return;
+        }
+
+        // 处理上下文菜单指令（右键指令）
+        if (interaction.isMessageContextMenuCommand() || interaction.isUserContextMenuCommand()) {
+            const command = interaction.client.commands.get(interaction.commandName);
+            
+            if (!command) {
+                console.warn(`[Interaction] ⚠️ 未找到上下文菜单处理器: ${interaction.commandName} (guild=${interaction.guild?.id || 'dm'} user=${interaction.user?.id || 'unknown'})`);
+                if (!interaction.replied && !interaction.deferred) {
+                    await interaction.reply({
+                        content: '❌ 该指令在当前机器人版本中未加载或已被移除。请联系管理员重新同步命令。',
+                        ephemeral: true,
+                    }).catch(() => {});
+                }
+                return;
+            }
+            
+            await command.execute(interaction);
+            return;
+        }
+        
+        // 处理按钮点击
+        if (interaction.isButton()) {
+            if (interaction.customId === 'open_form') {
+                // 检查表单使用权限
+                const formPermissionSettings = await getFormPermissionSettings(interaction.guild.id);
+                const hasFormPermission = checkFormPermission(interaction.member, formPermissionSettings);
+                
+                if (!hasFormPermission) {
+                    // 获取身份组名称用于错误消息
+                    let allowedRoleNames = [];
+                    if (formPermissionSettings && formPermissionSettings.allowedRoles) {
+                        for (const roleId of formPermissionSettings.allowedRoles) {
+                            try {
+                                const role = await interaction.guild.roles.fetch(roleId);
+                                if (role) allowedRoleNames.push(role.name);
+                            } catch (error) {
+                                // 忽略错误，继续处理其他身份组
+                            }
+                        }
+                    }
+                    
+                    return interaction.reply({
+                        content: getFormPermissionDeniedMessage(allowedRoleNames),
+                        flags: MessageFlags.Ephemeral
+                    });
+                }
+                
+                // 打开表单模态窗口
+                const modal = createFormModal();
+                await interaction.showModal(modal);
+            } else if (interaction.customId === 'open_review_form') {
+                // 打开审核表单模态窗口
+                const modal = createReviewModal();
+                await interaction.showModal(modal);
+            } else if (interaction.customId.startsWith('support_')) {
+                // 处理支持按钮（原有的提案系统）
+                await processVote(interaction);
+            } else if (interaction.customId.startsWith('court_support_')) {
+                // 处理法庭申请支持按钮
+                await processCourtSupport(interaction);
+            } else if (interaction.customId.startsWith('court_vote_support_') ||
+                       interaction.customId.startsWith('court_vote_oppose_')) {
+                // 处理法庭投票按钮
+                await processCourtVote(interaction);
+            } else if (interaction.customId.startsWith('selfmod_')) {
+                // 处理自助管理按钮
+                await processSelfModerationInteraction(interaction);
+            }
+            // === 投票系统按钮处理 ===
+            else if (interaction.customId === 'vote_setup') {
+                // 投票设置按钮
+                const modal = createVoteSetupModal();
+                await interaction.showModal(modal);
+            } else if (interaction.customId.startsWith('vote_') && !interaction.customId.startsWith('vote_setup')) {
+                // 处理投票按钮
+                await handleVoteButton(interaction);
+            }
+            // === 通知身份组系统按钮处理 ===
+            else if (interaction.customId === 'notification_roles_entry') {
+                // 通知身份组入口按钮
+                await handleNotificationButton(interaction);
+            }
+            // === 选举系统按钮处理 ===
+            else if (interaction.customId.startsWith('election_register_')) {
+                // 选举报名按钮
+                await handleRegistrationButton(interaction);
+            } else if (interaction.customId.startsWith('election_edit_registration_')) {
+                // 编辑报名按钮
+                await handleEditRegistration(interaction);
+            } else if (interaction.customId.startsWith('election_withdraw_registration_')) {
+                // 撤回报名按钮
+                await handleWithdrawRegistration(interaction);
+            } else if (interaction.customId.startsWith('election_start_anonymous_vote_')) {
+                // 开始匿名投票按钮
+                await handleAnonymousVoteStart(interaction);
+            } else if (interaction.customId.startsWith('election_anonymous_vote_select_')) {
+                // 匿名投票选择菜单
+                await handleAnonymousVoteSelect(interaction);
+            } else if (interaction.customId.startsWith('election_anonymous_vote_confirm_')) {
+                // 确认匿名投票按钮
+                await handleAnonymousVoteConfirm(interaction);
+            } else if (interaction.customId.startsWith('election_anonymous_vote_cancel_')) {
+                // 取消匿名投票按钮
+                await handleAnonymousVoteCancel(interaction);
+            } else if (interaction.customId.startsWith('election_vote_prev_') ||
+                       interaction.customId.startsWith('election_vote_next_')) {
+                // 投票分页按钮
+                await handleVotingPagination(interaction);
+            } else if (interaction.customId.startsWith('election_vote_complete_')) {
+                // 完成选择按钮
+                await handleVoteComplete(interaction);
+            } else if (interaction.customId.startsWith('appeal_registration_')) {
+                // 申诉报名按钮
+                const { handleAppealRegistration } = require('../../modules/election/components/appealComponents');
+                await handleAppealRegistration(interaction);
+            } else if (interaction.customId.startsWith('withdraw_registration_')) {
+                // 放弃参选按钮
+                const { handleWithdrawRegistration } = require('../../modules/election/components/appealComponents');
+                await handleWithdrawRegistration(interaction);
+            }
+            // === 赛事系统按钮处理 ===
+            else if (interaction.customId.startsWith('contest_application') && !interaction.customId.startsWith('contest_edit_')) {
+                // 赛事申请按钮（支持旧格式 contest_application 和新格式 contest_application_{trackId}）
+                const contestSettings = await getContestSettings(interaction.guild.id);
+                const hasPermission = checkContestApplicationPermission(interaction.member, contestSettings);
+                
+                if (!hasPermission) {
+                    let allowedRoleNames = [];
+                    if (contestSettings && contestSettings.applicationPermissionRoles) {
+                        for (const roleId of contestSettings.applicationPermissionRoles) {
+                            try {
+                                const role = await interaction.guild.roles.fetch(roleId);
+                                if (role) allowedRoleNames.push(role.name);
+                            } catch (error) {
+                                // 忽略错误
+                            }
+                        }
+                    }
+                    
+                    return interaction.reply({
+                        content: getApplicationPermissionDeniedMessage(allowedRoleNames),
+                        flags: MessageFlags.Ephemeral
+                    });
+                }
+                
+                // 提取轨道ID
+                let trackId;
+                if (interaction.customId.startsWith('contest_application_')) {
+                    trackId = interaction.customId.replace('contest_application_', '');
+                } else {
+                    // 旧格式按钮，使用默认轨道
+                    trackId = contestSettings?.defaultTrackId || 'default';
+                }
+                
+                const modal = createContestApplicationModal(trackId);
+                await interaction.showModal(modal);
+            } else if (interaction.customId.startsWith('contest_edit_')) {
+                // 编辑申请按钮
+                await processEditApplication(interaction);
+            } else if (interaction.customId.startsWith('proposal_edit_')) {
+                // 编辑议案按钮
+                await processEditProposal(interaction);
+            } else if (interaction.customId.startsWith('contest_confirm_')) {
+                // 确认建立频道按钮 - 显示选择界面
+                const applicationId = interaction.customId.replace('contest_confirm_', '');
+                const applicationData = await getContestApplication(applicationId);
+                
+                if (!applicationData) {
+                    return interaction.reply({
+                        content: '❌ 找不到对应的申请记录。',
+                        flags: MessageFlags.Ephemeral
+                    });
+                }
+                
+                // 检查权限：只有申请人可以确认建立频道
+                if (applicationData.applicantId !== interaction.user.id) {
+                    return interaction.reply({
+                        content: '❌ 只有申请人才能确认建立频道。',
+                        flags: MessageFlags.Ephemeral
+                    });
+                }
+                
+                // 获取外部服务器列表与全局开关
+                const contestSettings = await getContestSettings(interaction.guild.id);
+                const allowedExternalServers = contestSettings?.allowedExternalServers || [];
+                const showExternalSelect = !!(contestSettings && contestSettings.allowExternalSubmissionOptIn);
+                
+                const { createConfirmChannelSelection } = require('../../modules/contest/components/confirmChannelSelection');
+                const { embed, components } = createConfirmChannelSelection(applicationData, allowedExternalServers, showExternalSelect);
+                
+                await interaction.reply({
+                    embeds: [embed],
+                    components: components,
+                    ephemeral: true
+                });
+            } else if (interaction.customId.startsWith('proceed_channel_creation_')) {
+                // 继续设置频道详情按钮
+                const customIdParts = interaction.customId.replace('proceed_channel_creation_', '').split('_');
+                const applicationId = customIdParts[0];
+                const allowExternalServers = (customIdParts.length >= 2 && customIdParts[1] === 'true') ? true : false;
+                
+                const applicationData = await getContestApplication(applicationId);
+                
+                if (!applicationData) {
+                    return interaction.reply({
+                        content: '❌ 找不到对应的申请记录。',
+                        flags: MessageFlags.Ephemeral
+                    });
+                }
+                
+                // 检查权限：只有申请人可以确认建立频道
+                if (applicationData.applicantId !== interaction.user.id) {
+                    return interaction.reply({
+                        content: '❌ 只有申请人才能确认建立频道。',
+                        flags: MessageFlags.Ephemeral
+                    });
+                }
+                
+                const modal = createConfirmChannelModal(applicationData, allowExternalServers);
+                await interaction.showModal(modal);
+            } else if (interaction.customId.startsWith('cancel_channel_creation_')) {
+                // 取消建立频道
+                await interaction.update({
+                    content: '❌ 已取消建立频道。',
+                    embeds: [],
+                    components: []
+                });
+            } else if (interaction.customId.startsWith('contest_cancel_')) {
+                // 撤销办理按钮
+                await processCancelApplication(interaction);
+            } else if (interaction.customId.startsWith('contest_submit_')) {
+                // 投稿按钮
+                const contestChannelId = interaction.customId.replace('contest_submit_', '');
+                const modal = createSubmissionModal(contestChannelId);
+                await interaction.showModal(modal);
+            } else if (interaction.customId.startsWith('contest_manage_')) {
+                // 稿件管理按钮
+                await processSubmissionManagement(interaction);
+            } else if (interaction.customId.startsWith('manage_prev_') ||
+                       interaction.customId.startsWith('manage_next_')) {
+                // 稿件管理翻页按钮
+                const parts = interaction.customId.split('_');
+                const action = parts[1]; // prev 或 next
+                const contestChannelId = parts[2];
+                const page = parseInt(parts[3]);
+                
+                // 重新获取投稿数据并显示指定页面
+                const { getSubmissionsByChannel } = require('../../modules/contest/utils/contestDatabase');
+                const submissions = await getSubmissionsByChannel(contestChannelId);
+                const validSubmissions = submissions.filter(sub => sub.isValid)
+                    .sort((a, b) => new Date(a.submittedAt) - new Date(b.submittedAt));
+                
+                const { showSubmissionManagementPage } = require('../../modules/contest/services/submissionManagementService');
+                await showSubmissionManagementPage(interaction, validSubmissions, page, contestChannelId);
+            } else if (interaction.customId.startsWith('manage_close_')) {
+                // 关闭稿件管理界面
+                await interaction.update({
+                    content: '✅ 稿件管理界面已关闭。',
+                    embeds: [],
+                    components: []
+                });
+            } else if (interaction.customId.startsWith('confirm_delete_')) {
+                // 确认删除投稿
+                await processDeleteConfirmation(interaction);
+            } else if (interaction.customId.startsWith('quick_delete_')) {
+                // 快速删除投稿
+                await processDeleteConfirmation(interaction);
+            } else if (interaction.customId.startsWith('show_rejection_modal_')) {
+                // 显示拒稿说明模态窗口
+                const parts = interaction.customId.split('_');
+                const submissionId = parts[3];
+                const contestChannelId = parts[4];
+                
+                const modal = createRejectionModal(submissionId, contestChannelId);
+                await interaction.showModal(modal);
+            } else if (interaction.customId.startsWith('c_all_')) {
+                // 查看所有投稿作品按钮（新的短ID格式）
+                await displayService.handleViewAllSubmissions(interaction);
+            } else if (interaction.customId.startsWith('c_ipp5_') ||
+                       interaction.customId.startsWith('c_ipp10_') ||
+                       interaction.customId.startsWith('c_ipp20_')) {
+                // 每页显示数量设置按钮（新的短ID格式）
+                await displayService.handleItemsPerPageChange(interaction);
+            } else if (interaction.customId.startsWith('c_ff_') ||
+                       interaction.customId.startsWith('c_fp_') ||
+                       interaction.customId.startsWith('c_fn_') ||
+                       interaction.customId.startsWith('c_fl_') ||
+                       interaction.customId.startsWith('c_fref_')) {
+                // 完整作品列表翻页按钮（新的短ID格式）
+                await displayService.handleFullPageNavigation(interaction);
+            } else if (interaction.customId.startsWith('c_fpj_')) {
+                // 页面跳转按钮（新的短ID格式）
+                await displayService.handlePageJumpButton(interaction);
+            } else if (interaction.customId.startsWith('c_ref_')) {
+                // 刷新按钮（新的短ID格式）
+                await displayService.handlePageNavigation(interaction);
+            } else if (interaction.customId.startsWith('contest_view_all_')) {
+                // 查看所有投稿作品按钮（旧格式）
+                await displayService.handleViewAllSubmissions(interaction);
+            } else if (interaction.customId.startsWith('contest_items_per_page_')) {
+                // 每页显示数量设置按钮（旧格式）
+                await displayService.handleItemsPerPageChange(interaction);
+            } else if (interaction.customId.startsWith('contest_full_first_') ||
+                       interaction.customId.startsWith('contest_full_prev_') ||
+                       interaction.customId.startsWith('contest_full_next_') ||
+                       interaction.customId.startsWith('contest_full_last_') ||
+                       interaction.customId.startsWith('contest_full_refresh_')) {
+                // 完整作品列表翻页按钮（旧格式）
+                await displayService.handleFullPageNavigation(interaction);
+            } else if (interaction.customId.startsWith('contest_full_page_jump_')) {
+                // 页面跳转按钮（旧格式）
+                await displayService.handlePageJumpButton(interaction);
+            } else if (interaction.customId.startsWith('contest_prev_') ||
+                       interaction.customId.startsWith('contest_next_') ||
+                       interaction.customId.startsWith('contest_refresh_')) {
+                // 作品展示翻页按钮（旧格式）
+                await displayService.handlePageNavigation(interaction);
+            }
+            
+            // 新增管理操作按钮处理
+            if (interaction.customId.startsWith('manage_quick_delete_') ||
+                interaction.customId.startsWith('manage_delete_with_reason_') ||
+                interaction.customId.startsWith('manage_delete_page_')) {
+                await displayService.handleManagementAction(interaction);
+            }
+            
+            // 新增：获奖管理相关按钮
+            if (interaction.customId.startsWith('award_set_')) {
+                // 设置获奖作品按钮
+                const contestChannelId = interaction.customId.replace('award_set_', '');
+                await displayService.handleSetAward(interaction, contestChannelId);
+            } else if (interaction.customId.startsWith('award_remove_')) {
+                // 移除获奖作品按钮
+                const contestChannelId = interaction.customId.replace('award_remove_', '');
+                await displayService.handleRemoveAward(interaction, contestChannelId);
+            } else if (interaction.customId.startsWith('contest_finish_')) {
+                // 完赛按钮
+                const contestChannelId = interaction.customId.replace('contest_finish_', '');
+                await displayService.handleFinishContest(interaction, contestChannelId);
+            } else if (interaction.customId.startsWith('c_td_')) {
+                // 导出参赛作品链接
+                const contestChannelId = interaction.customId.replace('c_td_', '');
+                await displayService.handleDumpFullSubmissionsList(interaction, contestChannelId);
+            } else if (interaction.customId.startsWith('c_cp_')) {
+                // 复制内容
+                const contestChannelId = interaction.customId.replace('c_cp_', '');
+                await displayService.handleCopyContent(interaction, contestChannelId);
+            } else if (interaction.customId.startsWith('finish_contest_close_')) {
+                // 关闭完赛清单按钮
+                await interaction.update({
+                    content: '✅ 已关闭获奖清单预览。\n\n您可以继续管理比赛，或稍后重新查看完赛选项。',
+                    embeds: [],
+                    components: []
+                });
+            } else if (interaction.customId.startsWith('finish_contest_confirm_')) {
+                // 确认完赛按钮（第一次确认，现在显示二次确认）
+                const contestChannelId = interaction.customId.replace('finish_contest_confirm_', '');
+                await displayService.handleFinishContestConfirm(interaction, contestChannelId);
+            
+            // 新增：最终确认相关按钮
+            } else if (interaction.customId.startsWith('final_confirm_proceed_')) {
+                // 最终确认完赛按钮（真正的完赛操作）
+                const contestChannelId = interaction.customId.replace('final_confirm_proceed_', '');
+                await displayService.handleFinalConfirmProceed(interaction, contestChannelId);
+            } else if (interaction.customId.startsWith('final_confirm_cancel_')) {
+                // 取消最终确认按钮
+                const contestChannelId = interaction.customId.replace('final_confirm_cancel_', '');
+                await displayService.handleFinalConfirmCancel(interaction, contestChannelId);
+            } else if (interaction.customId.startsWith('sr_alert_resolve_')) {
+                await handleSelfRoleAlertResolveButton(interaction);
+            } else if (interaction.customId.startsWith('sr_wiz:')) {
+                await handleSelfRoleConfigWizardButton(interaction);
+            } else if (interaction.customId === 'self_role_apply_button' || interaction.customId === 'sr2_apply_button') {
+                await handleSelfRoleButton(interaction);
+            } else if (interaction.customId.startsWith('sr5_renew_keep_') || interaction.customId.startsWith('sr5_renew_leave_')) {
+                await handleSelfRoleRenewalDecision(interaction);
+            } else if (interaction.customId.startsWith('self_role_reason_reject_')) {
+                await showRejectReasonModal(interaction);
+            } else if (interaction.customId.startsWith('self_role_approve_') || interaction.customId.startsWith('self_role_reject_')) {
+                await processApprovalVote(interaction);
+            } else if (interaction.customId === 'admin_add_role_button') {
+                await handleAddRoleButton(interaction);
+            } else if (interaction.customId === 'admin_remove_role_button') {
+                await handleRemoveRoleButton(interaction);
+            } else if (interaction.customId === 'admin_edit_role_button') {
+                await handleEditRoleButton(interaction);
+            } else if (interaction.customId === 'admin_list_roles_button') {
+                await handleListRolesButton(interaction);
+            } else if (interaction.customId.startsWith('admin_roles_page_')) {
+                await handleRoleListPageChange(interaction);
+            }
+
+            // 参赛者身份组管理按钮
+            if (interaction.customId.startsWith('role_manage_')) {
+                if (interaction.customId.includes('_toggle_auto_')) {
+                    await toggleAutoGrant(interaction);
+                } else if (interaction.customId.includes('_grant_list_')) {
+                    await showUserList(interaction, 'grant');
+                } else if (interaction.customId.includes('_revoke_list_')) {
+                    await showUserList(interaction, 'revoke');
+                } else if (interaction.customId.includes('_bulk_grant_guide_')) {
+                    await showBulkGrantGuide(interaction);
+                } else if (interaction.customId.includes('_list_all_')) {
+                    await listAllParticipants(interaction);
+                }
+            }
+
+            // === 分服受控邀请系统按钮处理 ===
+            if (interaction.customId.startsWith('ci_request:')) {
+                const { handleInviteRequest } = require('../../modules/controlledInvite/services/inviteService');
+                await handleInviteRequest(interaction);
+            }
+
+            // === 频道总结预设按钮处理 ===
+            if (interaction.customId.startsWith('preset_')) {
+                await handlePresetButton(interaction);
+            }
+
+            return;
+        }
+        
+        // 处理模态窗口提交
+        if (interaction.isModalSubmit()) {
+            if (interaction.customId === 'form_submission') {
+                // 表单提交处理
+                await processFormSubmission(interaction);
+            } else if (interaction.customId === 'review_submission') {
+                // 审核提交处理
+                await processReviewSubmission(interaction);
+            } else if (interaction.customId.startsWith('selfmod_modal_')) {
+                // 自助管理模态窗口提交处理
+                await processSelfModerationInteraction(interaction);
+            }
+            // === 投票系统模态窗口处理 ===
+            else if (interaction.customId === 'vote_setup_modal') {
+                // 投票设置模态窗口提交
+                await handleVoteSetupSubmit(interaction);
+            }
+            // === 选举系统模态窗口处理 ===
+            else if (interaction.customId.startsWith('election_introduction_modal_')) {
+                // 选举自我介绍模态窗口提交
+                await handleIntroductionModal(interaction);
+            } else if (interaction.customId.startsWith('appeal_modal_')) {
+                // 申诉报名模态窗口提交
+                const { handleAppealModal } = require('../../modules/election/components/appealComponents');
+                await handleAppealModal(interaction);
+            } else if (interaction.customId.startsWith('admin_reason_')) {
+                // 管理员原因输入模态窗口提交
+                await handleReasonModal(interaction);
+            } else if (interaction.customId.startsWith('admin_edit_info_')) {
+                // 管理员编辑候选人信息模态窗口提交
+                await handleAdminEditInfo(interaction);
+            }
+            // === 赛事系统模态窗口处理 ===
+            else if (interaction.customId.startsWith('contest_application')) {
+                // 赛事申请表单提交（支持旧格式 contest_application 和新格式 contest_application_{trackId}）
+                await processContestApplication(interaction);
+            } else if (interaction.customId === 'contest_edit_application') {
+                // 编辑申请表单提交
+                await processEditApplicationSubmission(interaction);
+            } else if (interaction.customId.startsWith('proposal_edit_submission_')) {
+                // 编辑议案表单提交
+                await processEditProposalSubmission(interaction);
+            } else if (interaction.customId.startsWith('contest_confirm_channel_')) {
+                // 确认建立频道表单提交
+                await processChannelConfirmation(interaction);
+            } else if (interaction.customId.startsWith('contest_submission_')) {
+                // 投稿表单提交
+                await processContestSubmission(interaction);
+            } else if (interaction.customId.startsWith('rejection_reason_')) {
+                // 拒稿说明模态窗口提交
+                await processRejectionModal(interaction);
+            } else if (interaction.customId.startsWith('contest_page_jump_')) {
+                // 页面跳转模态窗口提交
+                await displayService.handlePageJumpSubmission(interaction);
+            }
+            // 新增：获奖作品设置模态框
+            if (interaction.customId.startsWith('award_modal_')) {
+                await displayService.handleAwardModalSubmission(interaction);
+            } else if (interaction.customId.startsWith('self_role_reason_reject_modal_')) {
+                await processRejectReasonModalSubmit(interaction);
+            } else if (interaction.customId.startsWith('self_role_reason_modal_') || interaction.customId.startsWith('self_role_reason_modal:')) {
+                // 自助身份组申请理由窗口提交
+                await handleReasonModalSubmit(interaction);
+            } else if (interaction.customId.startsWith('sr_wiz:')) {
+                await handleSelfRoleConfigWizardModal(interaction);
+            } else if (interaction.customId.startsWith('admin_add_role_modal_') || interaction.customId.startsWith('admin_edit_role_modal_')) {
+                await handleModalSubmit(interaction);
+            }
+            // === 频道总结预设 Modal 处理 ===
+            else if (interaction.customId.startsWith('preset_edit_modal_')) {
+                await handlePresetModal(interaction);
+            }
+            return;
+        }
+        
+        // 处理选择菜单（包含 String/Role/Channel 等所有 SelectMenu）
+        if (interaction.isAnySelectMenu()) {
+            if (interaction.customId.startsWith('submission_action_')) {
+                // 稿件管理操作选择
+                await processSubmissionAction(interaction);
+            } else if (interaction.customId === 'notification_roles_select') {
+                await handleNotificationButton(interaction);
+            } else if (interaction.customId.startsWith('election_select_first_choice_')) {
+                // 选举第一志愿选择
+                await handleFirstChoiceSelection(interaction);
+            } else if (interaction.customId.startsWith('election_select_second_choice_')) {
+                // 选举第二志愿选择
+                await handleSecondChoiceSelection(interaction);
+            } else if (interaction.customId.startsWith('election_anonymous_vote_select_')) {
+                // 匿名投票候选人选择菜单
+                await handleAnonymousVoteSelect(interaction);
+            } else if (interaction.customId.startsWith('admin_status_change_')) {
+                // 管理员状态变更选择菜单
+                await handleAdminStatusChange(interaction);
+            } else if (interaction.customId.startsWith('external_server_select_')) {
+                // 外部服务器投稿选择
+                const applicationId = interaction.customId.replace('external_server_select_', '');
+                const allowExternalServers = interaction.values[0] === 'yes';
+                
+                // 更新按钮状态
+                const updatedComponents = [...interaction.message.components];
+                const buttonRow = updatedComponents[1];
+                buttonRow.components[0].data.disabled = false; // 启用继续按钮
+                
+                // 存储选择到按钮的customId中（临时方案）
+                buttonRow.components[0].data.custom_id = `proceed_channel_creation_${applicationId}_${allowExternalServers}`;
+                
+                const selectionText = allowExternalServers ? '是 - 允许外部服务器投稿' : '否 - 仅允许本服务器投稿';
+                
+                await interaction.update({
+                    embeds: [{
+                        ...interaction.message.embeds[0].data,
+                        description: `**赛事名称：** ${interaction.message.embeds[0].data.description.split('\n')[0].replace('**赛事名称：** ', '')}\n\n✅ **外部服务器投稿：** ${selectionText}\n\n请点击下方按钮继续设置频道详情。`                    }],
+                    components: updatedComponents
+                });
+            } else if (interaction.customId.startsWith('manage_select_submission_')) {
+                // 投稿选择下拉菜单（在展示界面中的管理功能）
+                await displayService.handleSubmissionSelect(interaction);
+            } else if (interaction.customId === 'self_role_select_menu' || interaction.customId.startsWith('self_role_select_menu:')) {
+                await handleSelfRoleSelect(interaction);
+            } else if (interaction.customId.startsWith('sr_wiz:')) {
+                await handleSelfRoleConfigWizardSelect(interaction);
+            } else if (interaction.customId === 'admin_add_role_select') {
+                await handleRoleSelectForAdd(interaction);
+            } else if (interaction.customId === 'admin_remove_role_select') {
+                await handleRoleSelectForRemove(interaction);
+            } else if (interaction.customId === 'admin_edit_role_select') {
+                await handleRoleSelectForEdit(interaction);
+            }
+            return;
+        }
+    } catch (error) {
+        console.error('交互处理错误:', error);
+        try {
+            if (!interaction.replied && !interaction.deferred) {
+                await interaction.reply({
+                    content: '处理您的请求时出现错误。',
+                    flags: MessageFlags.Ephemeral
+                });
+            } else if (interaction.deferred) {
+                await interaction.editReply({
+                    content: '处理您的请求时出现错误。'
+                });
+            }
+        } catch (replyError) {
+            console.error('回复错误:', replyError);
+        }
+    }
+}
+
+module.exports = {
+    interactionCreateHandler,
+};

--- a/core/index.js
+++ b/core/index.js
@@ -1,0 +1,492 @@
+// src/core/index.js
+require('dotenv').config();
+
+// --- 进程级兜底日志（避免“Discord 无响应但控制台无日志”难以排查） ---
+// 可选：设置 FATAL_EXIT_ON_EXCEPTION=true，在发生 uncaughtException 时直接退出（建议配合进程守护工具使用）。
+const FATAL_EXIT_ON_EXCEPTION = String(process.env.FATAL_EXIT_ON_EXCEPTION || '').toLowerCase() === 'true';
+
+process.on('unhandledRejection', (reason) => {
+    console.error('❌ [Process] unhandledRejection:', reason);
+});
+
+process.on('uncaughtException', (err) => {
+    console.error('❌ [Process] uncaughtException:', err);
+    if (FATAL_EXIT_ON_EXCEPTION) {
+        process.exit(1);
+    }
+});
+
+const {
+    Client,
+    Collection,
+    Events, 
+    GatewayIntentBits,
+} = require('discord.js')
+
+const { clientReadyHandler } = require('./events/clientReady')
+const { interactionCreateHandler } = require('./events/interactionCreate')
+const { startProposalChecker } = require('../modules/proposal/services/proposalChecker');
+const { startCourtChecker } = require('../modules/court/services/courtChecker');
+const { startSelfModerationChecker } = require('../modules/selfModeration/services/moderationChecker');
+const { startAttachmentCleanupScheduler } = require('../modules/selfModeration/services/archiveService');
+const { startVoteChecker } = require('../modules/voting/services/voteChecker');
+const { startElectionScheduler } = require('../modules/election/services/electionScheduler');
+const { printTimeConfig } = require('./config/timeconfig');
+const { startActivityTracker } = require('../modules/selfRole/services/activityTracker');
+const { syncMissedActivity } = require('../modules/selfRole/services/autoSyncService');
+const { startSelfRoleApplicationChecker } = require('../modules/selfRole/services/applicationChecker');
+const { startSelfRoleLifecycleScheduler } = require('../modules/selfRole/services/lifecycleScheduler');
+const { startSelfRoleConsistencyChecker } = require('../modules/selfRole/services/consistencyChecker');
+
+// 身份组同步系统（多服务器）
+const {
+    startRoleSyncSystem,
+    roleSyncGuildMemberAddHandler,
+    roleSyncGuildMemberRemoveHandler,
+    roleSyncGuildMemberUpdateHandler,
+    roleSyncGuildRoleDeleteHandler,
+} = require('../modules/roleSync');
+
+// 导入命令
+const pingCommand = require('../shared/commands/ping');
+// const debugPermissionsCommand = require('../shared/commands/debugPermissions');  // 需要使用再取消注释
+const setCheckChannelCommand = require('../shared/commands/setCheckChannel');
+
+// 提案系统命令
+const setupFormCommand = require('../modules/proposal/commands/setupForm');
+const deleteEntryCommand = require('../modules/proposal/commands/deleteEntry');
+const withdrawProposalCommand = require('../modules/proposal/commands/withdrawProposal');
+const setFormPermissionsCommand = require('../modules/proposal/commands/setFormPermissions');
+const setSupportPermissionsCommand = require('../modules/proposal/commands/setSupportPermissions');
+const reviewProposalCommand = require('../modules/proposal/commands/reviewProposal');
+const setProposalReviewersCommand = require('../modules/proposal/commands/setProposalReviewers');
+
+// 审核系统命令
+const setupReviewCommand = require('../modules/creatorReview/commands/setupReview');
+const deleteReviewEntryCommand = require('../modules/creatorReview/commands/deleteReviewEntry');
+const addAllowPreviewServerCommand = require('../modules/creatorReview/commands/addAllowPreviewServer');
+const removeAllowPreviewServerCommand = require('../modules/creatorReview/commands/removeAllowPreviewServer');
+const addAllowedForumCommand = require('../modules/creatorReview/commands/addAllowedForum'); 
+const removeAllowedForumCommand = require('../modules/creatorReview/commands/removeAllowedForum');
+
+// 法庭系统命令
+const setAllowCourtRoleCommand = require('../modules/court/commands/setAllowCourtRole');
+const applyToCourtCommand = require('../modules/court/commands/applyToCourt');
+
+// 自助管理系统命令
+const deleteShitMessageCommand = require('../modules/selfModeration/commands/deleteShitMessage');
+const muteShitUserCommand = require('../modules/selfModeration/commands/muteShitUser');
+const seriousMuteCommand = require('../modules/selfModeration/commands/seriousMute');
+const setSelfModerationRolesCommand = require('../modules/selfModeration/commands/setSelfModerationRoles');
+const setSelfModerationChannelsCommand = require('../modules/selfModeration/commands/setSelfModerationChannels');
+const setSelfModerationCooldownCommand = require('../modules/selfModeration/commands/setSelfModerationCooldown');
+const setMessageTimeLimitCommand = require('../modules/selfModeration/commands/setMessageTimeLimit');
+const checkMyCooldownCommand = require('../modules/selfModeration/commands/checkMyCooldown');
+const setArchiveChannelCommand = require('../modules/selfModeration/commands/setArchiveChannel');
+const setArchiveViewRoleCommand = require('../modules/selfModeration/commands/setArchiveViewRole');
+const getArchiveViewPermissionCommand = require('../modules/selfModeration/commands/getArchiveViewPermission');
+const manageAttachmentCleanupCommand = require('../modules/selfModeration/commands/manageAttachmentCleanup');
+const manageSelfModerationBlacklistCommand = require('../modules/selfModeration/commands/manageSelfModerationBlacklist');
+
+// 赛事系统命令
+const setupContestApplicationCommand = require('../modules/contest/commands/setupContestApplication');
+const manageTrackCommand = require('../modules/contest/commands/manageTrack');
+const setContestReviewersCommand = require('../modules/contest/commands/setContestReviewers');
+const reviewContestApplicationCommand = require('../modules/contest/commands/reviewContestApplication');
+const updateContestInfoCommand = require('../modules/contest/commands/updateContestInfo');
+const updateContestTitleCommand = require('../modules/contest/commands/updateContestTitle');
+const initContestTagsCommand = require('../modules/contest/commands/initContestTags');
+const manageAllowedForumsCommand = require('../modules/contest/commands/manageAllowedForums');
+const manageExternalServersCommand = require('../modules/contest/commands/manageExternalServers');
+const cacheStats = require('../modules/contest/commands/cacheStats');
+const regenerateContestMessagesCommand = require('../modules/contest/commands/regenerateContestMessages');
+const bindParticipantRoleCommand = require('../modules/contest/commands/bindParticipantRole');
+const manageParticipantRoleCommand = require('../modules/contest/commands/manageParticipantRole');
+const setExternalSubmissionOptInCommand = require('../modules/contest/commands/setExternalSubmissionOptIn');
+const viewSubmissionsCommand = require('../modules/contest/commands/viewSubmissions');
+const viewSubmissionsContextCommand = require('../modules/contest/commands/viewSubmissionsContext');
+const manageApplicationNotifyCommand = require('../modules/contest/commands/manageApplicationNotify');
+
+// 自动清理系统命令（合并后）
+const keywordManagerCommand = require('../modules/autoCleanup/commands/keywordManager');
+const exemptManagerCommand = require('../modules/autoCleanup/commands/exemptManager');
+const cleanupManagerCommand = require('../modules/autoCleanup/commands/cleanupManager');
+
+// 频道总结系统命令
+const summarizeChannelCommand = require('../modules/channelSummary/commands/summarizeChannel');
+const summaryPresetCommand = require('../modules/channelSummary/commands/summaryPreset');
+
+// 投票系统命令
+const createVoteCommand = require('../modules/voting/commands/createVote');
+// 添加新的通知身份组命令
+const notificationRolesCommand = require('../modules/voting/commands/notificationRoles');
+
+// 选举系统命令 - 完整的命令列表
+const setElectionPositionsCommand = require('../modules/election/commands/setElectionPositions');
+const setElectionTimeScheduleCommand = require('../modules/election/commands/setElectionTimeSchedule');
+const setupElectionEntryCommand = require('../modules/election/commands/setupElectionEntry');
+const getElectionStatusCommand = require('../modules/election/commands/getElectionStatus');
+const setRegistrationRolesCommand = require('../modules/election/commands/setRegistrationRoles');
+const setVotingRolesCommand = require('../modules/election/commands/setVotingRoles');
+const setNotificationRolesCommand = require('../modules/election/commands/setNotificationRoles');
+const getTieAnalysisCommand = require('../modules/election/commands/getTieAnalysis');
+const reprocessElectionResultsCommand = require('../modules/election/commands/reprocessElectionResults');
+const viewCandidateInfoCommand = require('../modules/election/commands/viewCandidateInfo');
+const manageCandidateStatusCommand = require('../modules/election/commands/manageCandidateStatus');
+const scanCandidateMessagesCommand = require('../modules/election/commands/scanCandidateMessages');
+const editCandidateInfoCommand = require('../modules/election/commands/editCandidateInfo');
+const clearElectionVoteCommand = require('../modules/election/commands/clearElectionVote');
+const viewVoteRemovalLogsCommand = require('../modules/election/commands/viewVoteRemovalLogs');
+const updateVotingCandidatesCommand = require('../modules/election/commands/updateVotingCandidates');
+
+const { messageCreateHandler } = require('./events/messageCreate');
+
+// 论坛重建系统命令
+const rebuildForumCommand = require('../modules/forumRebuilder/commands/rebuildForum');
+
+// 帖子重建系统命令
+const rebuildThreadsCommand = require('../modules/threadRebuilder/commands/rebuildThreads');
+const deleteRebuiltMessageCommand = require('../modules/threadRebuilder/commands/deleteRebuiltMessage');
+
+// 自助文件上传系统命令
+const uploadCommand = require('../modules/selfFileUpload/commands/uploadFile');
+const whoisCommand = require('../modules/selfFileUpload/commands/queryAnonymousLog');
+const manageOptOutCommand = require('../modules/selfFileUpload/commands/manageOptOut.js');
+const collectBackupsCommand = require('../modules/selfFileUpload/commands/collectBackups.js');
+
+// 补卡系统命令
+// const processBackupCardsCommand = require('../modules/backupCards/commands/processBackupCards');
+// const testBackupCardsCommand = require('../modules/backupCards/commands/testBackupCards');
+// const archiveBackupThreadsCommand = require('../modules/backupCards/commands/archiveBackupThreads');
+// const cleanupFuzzyMatchesCommand = require('../modules/backupCards/commands/cleanupFuzzyMatches');
+
+//// 自助身份组系统命令
+const setupRolePanelCommand = require('../modules/selfRole/commands/setupRolePanel');
+const setupAdminPanelCommand = require('../modules/selfRole/commands/setupAdminPanel');
+const recalculateActivityCommand = require('../modules/selfRole/commands/recalculateActivity');
+const checkActivityCommand = require('../modules/selfRole/commands/checkActivity');
+const debugRolesCommand = require('../modules/selfRole/commands/debugRoles'); // 调试命令
+const clearCooldownCommand = require('../modules/selfRole/commands/clearCooldown');
+const configureRolesCommand = require('../modules/selfRole/commands/configureRoles');
+const withdrawSelfRoleApplicationCommand = require('../modules/selfRole/commands/withdrawApplication');
+const selfRoleOpsCommand = require('../modules/selfRole/commands/selfRoleOps');
+const selfRoleWizardCommand = require('../modules/selfRole/commands/selfRoleWizard');
+let selfRoleTestCommand = null;
+if (String(process.env.SELF_ROLE_ENABLE_TEST_COMMANDS || '').toLowerCase() === 'true') {
+    // 仅在测试环境启用（避免生产环境误注册）
+    selfRoleTestCommand = require('../modules/selfRole/commands/selfRoleTest');
+    console.log('[SelfRole] 🧪 SELF_ROLE_ENABLE_TEST_COMMANDS=true：已启用自助身份组测试命令注册。');
+}
+
+// 身份组同步系统命令
+const roleSyncConfigCommand = require('../modules/roleSync/commands/roleSyncConfig');
+
+// 处罚系统
+const { startPunishmentSystem } = require('../modules/punishment');
+const punishCommand = require('../modules/punishment/commands/punish');
+
+// 分服受控邀请系统
+const { startControlledInviteSystem, controlledInviteGuildMemberAddHandler } = require('../modules/controlledInvite');
+const controlledInviteConfigCommand = require('../modules/controlledInvite/commands/controlledInviteConfig');
+const controlledInviteParamsCommand = require('../modules/controlledInvite/commands/controlledInviteParams');
+const controlledInviteToggleCommand = require('../modules/controlledInvite/commands/controlledInviteToggle');
+const viewMyControlledInviteStatusCommand = require('../modules/controlledInvite/commands/viewMyControlledInviteStatus');
+
+const DISCORD_REST_TIMEOUT_MS = (() => {
+    const n = Number(process.env.DISCORD_REST_TIMEOUT_MS);
+    return Number.isFinite(n) && n > 0 ? n : 15000;
+})();
+
+const client = new Client({
+    intents: [
+        GatewayIntentBits.Guilds,
+        GatewayIntentBits.GuildMessages,
+        GatewayIntentBits.GuildMembers,
+        GatewayIntentBits.GuildMessageReactions, // 需要这个intent来监控reaction
+        GatewayIntentBits.MessageContent,
+    ],
+    rest: {
+        // REST 请求超时（ms）。避免网络异常时请求长时间挂起导致交互无响应。
+        timeout: DISCORD_REST_TIMEOUT_MS,
+    },
+});
+
+// --- Discord 客户端/REST 诊断日志（用于定位“无响应但无日志”） ---
+client.on('error', (err) => {
+    console.error('❌ [Discord] client error:', err);
+});
+client.on('warn', (info) => {
+    console.warn('⚠️ [Discord] client warn:', info);
+});
+client.on('shardError', (err, shardId) => {
+    console.error(`❌ [Discord] shardError shard=${shardId}:`, err);
+});
+client.on('shardDisconnect', (event, shardId) => {
+    console.warn(`⚠️ [Discord] shardDisconnect shard=${shardId} code=${event?.code} reason=${event?.reason}`);
+});
+client.on('shardReconnecting', (shardId) => {
+    console.warn(`⚠️ [Discord] shardReconnecting shard=${shardId}`);
+});
+client.on('shardResume', (shardId, replayedEvents) => {
+    console.log(`✅ [Discord] shardResume shard=${shardId} replayed=${replayedEvents}`);
+});
+
+try {
+    client.rest.on('rateLimited', (info) => {
+        const route = info?.route || info?.path || 'unknown';
+        const method = info?.method || 'unknown';
+        const timeToReset = info?.timeToReset;
+        console.warn(`⚠️ [Discord][REST] rateLimited ${method} ${route} resetInMs=${timeToReset}`);
+    });
+} catch (_) {}
+
+const HEALTH_LOG_INTERVAL_MINUTES = Number(process.env.HEALTH_LOG_INTERVAL_MINUTES || 0);
+if (Number.isFinite(HEALTH_LOG_INTERVAL_MINUTES) && HEALTH_LOG_INTERVAL_MINUTES > 0) {
+    setInterval(() => {
+        console.log(
+            `[Health] wsStatus=${client.ws?.status} ping=${client.ws?.ping} guilds=${client.guilds?.cache?.size} mem=${Math.round(process.memoryUsage().rss / 1024 / 1024)}MB`,
+        );
+    }, Math.floor(HEALTH_LOG_INTERVAL_MINUTES * 60 * 1000));
+}
+
+client.commands = new Collection();
+
+// 注册所有命令
+client.commands.set(pingCommand.data.name, pingCommand);
+// client.commands.set(debugPermissionsCommand.data.name, debugPermissionsCommand); // 需要使用再取消注释
+client.commands.set(setCheckChannelCommand.data.name, setCheckChannelCommand);
+
+// 提案系统命令
+client.commands.set(setupFormCommand.data.name, setupFormCommand);
+client.commands.set(deleteEntryCommand.data.name, deleteEntryCommand);
+client.commands.set(withdrawProposalCommand.data.name, withdrawProposalCommand);
+client.commands.set(setFormPermissionsCommand.data.name, setFormPermissionsCommand);
+client.commands.set(setSupportPermissionsCommand.data.name, setSupportPermissionsCommand);
+client.commands.set(reviewProposalCommand.data.name, reviewProposalCommand);
+client.commands.set(setProposalReviewersCommand.data.name, setProposalReviewersCommand);
+
+// 审核系统命令
+client.commands.set(setupReviewCommand.data.name, setupReviewCommand);
+client.commands.set(deleteReviewEntryCommand.data.name, deleteReviewEntryCommand);
+client.commands.set(addAllowPreviewServerCommand.data.name, addAllowPreviewServerCommand);
+client.commands.set(removeAllowPreviewServerCommand.data.name, removeAllowPreviewServerCommand);
+client.commands.set(addAllowedForumCommand.data.name, addAllowedForumCommand);
+client.commands.set(removeAllowedForumCommand.data.name, removeAllowedForumCommand);
+
+// 法庭系统命令
+client.commands.set(setAllowCourtRoleCommand.data.name, setAllowCourtRoleCommand);
+client.commands.set(applyToCourtCommand.data.name, applyToCourtCommand);
+
+// 自助管理系统命令
+client.commands.set(deleteShitMessageCommand.data.name, deleteShitMessageCommand);
+client.commands.set(muteShitUserCommand.data.name, muteShitUserCommand);
+client.commands.set(seriousMuteCommand.data.name, seriousMuteCommand);
+client.commands.set(setSelfModerationRolesCommand.data.name, setSelfModerationRolesCommand);
+client.commands.set(setSelfModerationChannelsCommand.data.name, setSelfModerationChannelsCommand);
+client.commands.set(setSelfModerationCooldownCommand.data.name, setSelfModerationCooldownCommand);
+client.commands.set(setMessageTimeLimitCommand.data.name, setMessageTimeLimitCommand);
+client.commands.set(checkMyCooldownCommand.data.name, checkMyCooldownCommand);
+client.commands.set(setArchiveChannelCommand.data.name, setArchiveChannelCommand);
+client.commands.set(setArchiveViewRoleCommand.data.name, setArchiveViewRoleCommand);
+client.commands.set(getArchiveViewPermissionCommand.data.name, getArchiveViewPermissionCommand);
+client.commands.set(manageAttachmentCleanupCommand.data.name, manageAttachmentCleanupCommand);
+client.commands.set(manageSelfModerationBlacklistCommand.data.name, manageSelfModerationBlacklistCommand);
+
+// 赛事系统命令
+client.commands.set(setupContestApplicationCommand.data.name, setupContestApplicationCommand);
+client.commands.set(manageTrackCommand.data.name, manageTrackCommand);
+client.commands.set(setContestReviewersCommand.data.name, setContestReviewersCommand);
+client.commands.set(reviewContestApplicationCommand.data.name, reviewContestApplicationCommand);
+client.commands.set(updateContestInfoCommand.data.name, updateContestInfoCommand);
+client.commands.set(updateContestTitleCommand.data.name, updateContestTitleCommand);
+client.commands.set(initContestTagsCommand.data.name, initContestTagsCommand);
+client.commands.set(manageAllowedForumsCommand.data.name, manageAllowedForumsCommand);
+client.commands.set(manageExternalServersCommand.data.name, manageExternalServersCommand);
+client.commands.set(cacheStats.data.name, cacheStats);
+client.commands.set(regenerateContestMessagesCommand.data.name, regenerateContestMessagesCommand);
+client.commands.set(bindParticipantRoleCommand.data.name, bindParticipantRoleCommand);
+client.commands.set(manageParticipantRoleCommand.data.name, manageParticipantRoleCommand);
+client.commands.set(setExternalSubmissionOptInCommand.data.name, setExternalSubmissionOptInCommand);
+client.commands.set(viewSubmissionsCommand.data.name, viewSubmissionsCommand);
+client.commands.set(viewSubmissionsContextCommand.data.name, viewSubmissionsContextCommand);
+client.commands.set(manageApplicationNotifyCommand.data.name, manageApplicationNotifyCommand);
+
+// 自动清理系统命令（合并后）
+client.commands.set(keywordManagerCommand.data.name, keywordManagerCommand);
+client.commands.set(exemptManagerCommand.data.name, exemptManagerCommand);
+client.commands.set(cleanupManagerCommand.data.name, cleanupManagerCommand);
+
+// 论坛重建系统命令
+client.commands.set(rebuildForumCommand.data.name, rebuildForumCommand);
+
+// 帖子重建系统命令
+client.commands.set(rebuildThreadsCommand.data.name, rebuildThreadsCommand);
+client.commands.set(deleteRebuiltMessageCommand.data.name, deleteRebuiltMessageCommand);
+
+// 补卡系统命令
+// client.commands.set(processBackupCardsCommand.data.name, processBackupCardsCommand);
+// client.commands.set(testBackupCardsCommand.data.name, testBackupCardsCommand);
+// client.commands.set(archiveBackupThreadsCommand.data.name, archiveBackupThreadsCommand);
+// client.commands.set(cleanupFuzzyMatchesCommand.data.name, cleanupFuzzyMatchesCommand);
+
+// 频道总结系统命令
+client.commands.set(summarizeChannelCommand.data.name, summarizeChannelCommand);
+client.commands.set(summaryPresetCommand.data.name, summaryPresetCommand);
+
+// 投票系统命令
+client.commands.set(createVoteCommand.data.name, createVoteCommand);
+// 注册新的通知身份组命令
+client.commands.set(notificationRolesCommand.data.name, notificationRolesCommand);
+
+// 选举系统命令 - 完整注册
+client.commands.set(setElectionPositionsCommand.data.name, setElectionPositionsCommand);
+client.commands.set(setElectionTimeScheduleCommand.data.name, setElectionTimeScheduleCommand);
+client.commands.set(setupElectionEntryCommand.data.name, setupElectionEntryCommand);
+client.commands.set(getElectionStatusCommand.data.name, getElectionStatusCommand);
+client.commands.set(setRegistrationRolesCommand.data.name, setRegistrationRolesCommand);
+client.commands.set(setVotingRolesCommand.data.name, setVotingRolesCommand);
+client.commands.set(setNotificationRolesCommand.data.name, setNotificationRolesCommand);
+client.commands.set(getTieAnalysisCommand.data.name, getTieAnalysisCommand);
+client.commands.set(reprocessElectionResultsCommand.data.name, reprocessElectionResultsCommand);
+client.commands.set(viewCandidateInfoCommand.data.name, viewCandidateInfoCommand);
+client.commands.set(manageCandidateStatusCommand.data.name, manageCandidateStatusCommand);
+client.commands.set(scanCandidateMessagesCommand.data.name, scanCandidateMessagesCommand);
+client.commands.set(editCandidateInfoCommand.data.name, editCandidateInfoCommand);
+client.commands.set(clearElectionVoteCommand.data.name, clearElectionVoteCommand);
+client.commands.set(viewVoteRemovalLogsCommand.data.name, viewVoteRemovalLogsCommand);
+client.commands.set(updateVotingCandidatesCommand.data.name, updateVotingCandidatesCommand);
+
+// 自助文件上传系统命令
+client.commands.set(uploadCommand.data.name, uploadCommand);
+client.commands.set(whoisCommand.data.name, whoisCommand);
+client.commands.set(manageOptOutCommand.data.name, manageOptOutCommand);
+client.commands.set(collectBackupsCommand.data.name, collectBackupsCommand);
+
+//// 自助身份组系统命令
+client.commands.set(setupRolePanelCommand.data.name, setupRolePanelCommand);
+client.commands.set(setupAdminPanelCommand.data.name, setupAdminPanelCommand);
+client.commands.set(recalculateActivityCommand.data.name, recalculateActivityCommand);
+client.commands.set(checkActivityCommand.data.name, checkActivityCommand);
+client.commands.set(debugRolesCommand.data.name, debugRolesCommand); // 调试命令
+client.commands.set(clearCooldownCommand.data.name, clearCooldownCommand);
+client.commands.set(configureRolesCommand.data.name, configureRolesCommand);
+client.commands.set(withdrawSelfRoleApplicationCommand.data.name, withdrawSelfRoleApplicationCommand);
+client.commands.set(selfRoleOpsCommand.data.name, selfRoleOpsCommand);
+client.commands.set(selfRoleWizardCommand.data.name, selfRoleWizardCommand);
+if (selfRoleTestCommand) {
+    client.commands.set(selfRoleTestCommand.data.name, selfRoleTestCommand);
+}
+client.commands.set(roleSyncConfigCommand.data.name, roleSyncConfigCommand);
+
+// 处罚系统命令
+client.commands.set(punishCommand.data.name, punishCommand);
+
+// 分服受控邀请系统命令
+client.commands.set(controlledInviteConfigCommand.data.name, controlledInviteConfigCommand);
+client.commands.set(controlledInviteParamsCommand.data.name, controlledInviteParamsCommand);
+client.commands.set(controlledInviteToggleCommand.data.name, controlledInviteToggleCommand);
+client.commands.set(viewMyControlledInviteStatusCommand.data.name, viewMyControlledInviteStatusCommand);
+
+client.once(Events.ClientReady, async (readyClient) => {
+    try {
+        // 启动时强制同步命令（clientReadyHandler 内部会执行 rest.put 刷新命令）
+        // 若开启 STRICT_COMMAND_SYNC=true 且存在失败 guild，将直接抛错并中止启动。
+        await clientReadyHandler(readyClient);
+    } catch (err) {
+        console.error('❌ 启动阶段命令同步失败，进程即将退出：', err);
+        try {
+            readyClient.destroy();
+        } catch (_) {}
+        process.exit(1);
+        return;
+    }
+    printTimeConfig();
+    
+    startProposalChecker(readyClient);
+    console.log('✅ 提案检查器已启动');
+    
+    startCourtChecker(readyClient);
+    console.log('✅ 法庭系统检查器已启动');
+    
+    startSelfModerationChecker(readyClient);
+    console.log('✅ 自助管理检查器已启动');
+    
+    startAttachmentCleanupScheduler(readyClient);
+    console.log('✅ 附件清理定时器已启动');
+    
+    startVoteChecker(readyClient);
+    console.log('✅ 投票检查器已启动');
+    
+    startElectionScheduler(readyClient);
+    console.log('✅ 选举调度器已启动');
+    
+    // 初始化自动清理系统
+    console.log('✅ 自动清理系统已启动');
+
+    startActivityTracker();
+
+    // SelfRole 申请过期检查器（预留名额释放/旧数据兼容迁移）
+    startSelfRoleApplicationChecker(readyClient);
+    
+    // 在机器人完全启动前，执行离线数据同步
+    await syncMissedActivity(readyClient);
+
+    // SelfRole grant 生命周期调度器（周期询问/onlyWhenFull/强制清退）
+    startSelfRoleLifecycleScheduler(readyClient);
+
+    // SelfRole 一致性巡检（grant/面板/角色残留等）
+    startSelfRoleConsistencyChecker(readyClient);
+
+    // 启动身份组同步系统
+    await startRoleSyncSystem(readyClient);
+
+    // 启动处罚系统
+    await startPunishmentSystem(readyClient);
+
+    // 启动分服受控邀请系统
+    await startControlledInviteSystem(readyClient);
+
+    console.log('\n🤖 机器人已完全启动，所有系统正常运行！');
+    console.log('🏆 赛事管理系统已加载');
+    console.log('🧹 自动消息清理系统已加载');
+    console.log('🗳️ 选举系统已完全加载 (包含16个命令)');
+    console.log('🎴 补卡管理系统已加载 (包含3个命令)');
+})
+
+client.on(Events.InteractionCreate, interactionCreateHandler)
+
+// 添加消息创建事件处理器
+client.on(Events.MessageCreate, messageCreateHandler);
+client.on(Events.GuildMemberAdd, roleSyncGuildMemberAddHandler);
+client.on(Events.GuildMemberAdd, controlledInviteGuildMemberAddHandler);
+client.on(Events.GuildMemberRemove, roleSyncGuildMemberRemoveHandler);
+client.on(Events.GuildMemberUpdate, roleSyncGuildMemberUpdateHandler);
+client.on(Events.GuildRoleDelete, roleSyncGuildRoleDeleteHandler);
+
+function normalizeDiscordToken(raw) {
+    if (!raw) return '';
+    let token = String(raw).trim();
+    if (!token) return '';
+    // 兼容误填 "Bot <token>"
+    token = token.replace(/^Bot\s+/i, '').trim();
+    return token;
+}
+
+const token = normalizeDiscordToken(process.env.DISCORD_TOKEN);
+if (!token || token.includes('PASTE_YOUR_DISCORD_BOT_TOKEN')) {
+    console.error('❌ 缺少或未正确配置 DISCORD_TOKEN。请在项目根目录 .env 中设置 DISCORD_TOKEN=你的机器人Token 后重启。');
+    process.exit(1);
+}
+if (token.split('.').length !== 3) {
+    console.error('❌ DISCORD_TOKEN 格式异常：应为 3 段以英文点号分隔的 token。请检查是否有空格/换行/前缀 Bot 等。');
+    process.exit(1);
+}
+
+// 确保后续模块（如命令同步）拿到的是清洗后的 token
+process.env.DISCORD_TOKEN = token;
+
+client.login(token).catch((err) => {
+    console.error('❌ Discord 登录失败。常见原因：Token 粘贴错误 / Token 已被重置失效 / 使用了非 Bot Token。');
+    console.error(err);
+    process.exit(1);
+});

--- a/src/commands/summarizeChannel.js
+++ b/src/commands/summarizeChannel.js
@@ -1,0 +1,350 @@
+// src/modules/channelSummary/commands/summarizeChannel.js
+
+const {
+  SlashCommandBuilder,
+  PermissionFlagsBits,
+  AttachmentBuilder,
+} = require("discord.js");
+const { parseTimeInput, validateTimeRange } = require("../utils/timeParser");
+const { collectMessages } = require("../services/messageCollector");
+const { generateSummary } = require("../services/aiSummaryService");
+const {
+  generateMessagesJSON,
+  saveToTempFile,
+  cleanupTempFiles,
+} = require("../services/jsonExporter");
+const {
+  formatSummaryForDiscord,
+  generateSummaryText,
+  generatePlainTextSummary,
+  splitLongText,
+  createSummaryTextFile,
+} = require("../utils/summaryFormatter");
+const config = require("../config/summaryConfig");
+
+/**
+ * 格式化 Date → "YYYY-MM-DD HH:mm"
+ */
+function formatDateTime(date) {
+  const y = date.getFullYear();
+  const m = String(date.getMonth() + 1).padStart(2, "0");
+  const d = String(date.getDate()).padStart(2, "0");
+  const hh = String(date.getHours()).padStart(2, "0");
+  const mm = String(date.getMinutes()).padStart(2, "0");
+  return `${y}-${m}-${d} ${hh}:${mm}`;
+}
+
+/**
+ * 为未提供的时间参数填充默认值。
+ * 返回 { startTimeStr, endTimeStr, usedDefaultTime }
+ */
+function applyTimeDefaults(startTimeStr, endTimeStr) {
+  const now = new Date();
+  let usedDefaultTime = false;
+
+  let resolvedEnd = endTimeStr;
+  let resolvedStart = startTimeStr;
+
+  if (!resolvedEnd || !resolvedEnd.trim()) {
+    resolvedEnd = formatDateTime(now);
+    usedDefaultTime = true;
+  }
+  if (!resolvedStart || !resolvedStart.trim()) {
+    const thirtyDaysAgo = new Date(now.getTime() - config.DEFAULT_TIME_RANGE_DAYS * 24 * 60 * 60 * 1000);
+    resolvedStart = formatDateTime(thirtyDaysAgo);
+    usedDefaultTime = true;
+  }
+
+  return { startTimeStr: resolvedStart, endTimeStr: resolvedEnd, usedDefaultTime };
+}
+
+const data = new SlashCommandBuilder()
+  .setName("总结频道内容")
+  .setDescription("总结指定时间段内的频道消息")
+  .addStringOption((option) =>
+    option
+      .setName("开始时间")
+      .setDescription("开始时间 (YYYY-MM-DD HH:mm)，不填默认 30 天前")
+      .setRequired(false),
+  )
+  .addStringOption((option) =>
+    option
+      .setName("结束时间")
+      .setDescription("结束时间 (YYYY-MM-DD HH:mm)，不填默认当前时间")
+      .setRequired(false),
+  )
+  .addStringOption((option) =>
+    option
+      .setName("模型")
+      .setDescription("指定用于总结的AI模型，不填则使用默认模型")
+      .setRequired(false),
+  )
+  .addStringOption((option) =>
+    option
+      .setName("url")
+      .setDescription("可选，OpenAI 兼容接口地址（覆盖默认 Base URL）")
+      .setRequired(false),
+  )
+  .addStringOption((option) =>
+    option
+      .setName("api")
+      .setDescription("可选，API Key（覆盖默认环境变量）")
+      .setRequired(false),
+  )
+  .addStringOption((option) =>
+    option
+      .setName("额外提示词")
+      .setDescription("可选，附加在默认系统提示词之后")
+      .setRequired(false),
+  );
+
+/**
+ * 执行频道总结的核心逻辑，可被 slash command 和 preset flow 共同调用。
+ * @param {Interaction} interaction
+ * @param {object} params
+ * @param {string|null} params.startTimeStr
+ * @param {string|null} params.endTimeStr
+ * @param {string|null} params.model
+ * @param {string|null} params.apiBaseUrl
+ * @param {string|null} params.apiKey
+ * @param {string|null} params.extraPrompt
+ * @param {object} [params.channel]
+ */
+async function executeSummary(interaction, params) {
+  if (!interaction || !interaction.isRepliable()) {
+    console.error("无效的交互对象");
+    return;
+  }
+
+  let channel = params.channel || interaction.channel;
+  if (!channel) {
+    try {
+      channel = await interaction.guild.channels.fetch(interaction.channelId);
+    } catch (error) {
+      console.error("无法获取频道信息:", error);
+      return;
+    }
+  }
+
+  try {
+    await interaction.deferReply({ ephemeral: true });
+  } catch (deferError) {
+    console.error("Defer回复失败:", deferError);
+    try {
+      await interaction.reply({
+        content: "❌ 交互已过期，请重新尝试命令。",
+        ephemeral: true,
+      });
+    } catch (replyError) {
+      console.error("直接回复也失败:", replyError);
+    }
+    return;
+  }
+
+  if (!channel) {
+    return await interaction.editReply(
+      "❌ 无法获取频道信息，请确保在正确的频道中使用此命令。",
+    );
+  }
+
+  const isValidChannel =
+    channel.isTextBased() ||
+    (channel.isThread && channel.isThread()) ||
+    channel.type === 0 ||
+    channel.type === 11;
+
+  if (!isValidChannel) {
+    return await interaction.editReply(
+      "❌ 此命令只能在文字频道或线程中使用。",
+    );
+  }
+
+  const { model, apiBaseUrl, apiKey, extraPrompt } = params;
+
+  // 应用时间默认值
+  const { startTimeStr, endTimeStr, usedDefaultTime } = applyTimeDefaults(
+    params.startTimeStr,
+    params.endTimeStr,
+  );
+
+  const startTime = parseTimeInput(startTimeStr);
+  const endTime = parseTimeInput(endTimeStr);
+  validateTimeRange(startTime, endTime, config.MAX_TIME_RANGE_DAYS);
+
+  // 进度消息：若使用了默认时间，追加说明
+  let collectingMsg = "⏳ 开始收集消息...";
+  if (usedDefaultTime) {
+    collectingMsg += `\n> 📌 未检测到时间参数，已自动拉取本频道近 ${config.DEFAULT_TIME_RANGE_DAYS} 天内的消息（上限 ${config.MAX_MESSAGES} 条）进行总结。`;
+  }
+  await interaction.editReply(collectingMsg);
+
+  const messages = await collectMessages(
+    channel,
+    startTime,
+    endTime,
+    config.MAX_MESSAGES,
+  );
+
+  if (messages.length === 0) {
+    return await interaction.editReply(
+      "❌ 在指定时间范围内没有找到任何消息。",
+    );
+  }
+
+  await interaction.editReply(
+    `📊 收集到 ${messages.length} 条消息，正在生成AI总结...`,
+  );
+
+  const channelInfo = {
+    id: channel.id,
+    name: channel.name || "未命名频道",
+    type: channel.type,
+    timeRange: {
+      start: startTime.toISOString(),
+      end: endTime.toISOString(),
+    },
+  };
+
+  const aiSummary = await generateSummary(messages, channelInfo, model, {
+    apiBaseUrl,
+    apiKey,
+    extraPrompt,
+  });
+
+  await interaction.editReply("📝 正在生成文件和总结...");
+
+  const messagesData = generateMessagesJSON(channelInfo, messages);
+  const fileInfo = await saveToTempFile(messagesData, channelInfo.name);
+
+  const attachment = new AttachmentBuilder(fileInfo.filePath, {
+    name: fileInfo.fileName,
+  });
+
+  cleanupTempFiles(config.FILE_RETENTION_HOURS).catch(console.warn);
+
+  const completionEmbed = {
+    color: 0x00ff00,
+    title: "✅ 频道内容总结完成",
+    fields: [
+      { name: "频道", value: channelInfo.name, inline: true },
+      { name: "消息数量", value: messages.length.toString(), inline: true },
+      {
+        name: "参与用户",
+        value: aiSummary.participant_stats.total_participants.toString(),
+        inline: true,
+      },
+      {
+        name: "时间范围",
+        value: `${startTimeStr} 至 ${endTimeStr}`,
+        inline: false,
+      },
+      {
+        name: "文件大小",
+        value: `${Math.round(fileInfo.size / 1024)} KB`,
+        inline: true,
+      },
+    ],
+    description: "📁 消息数据已导出到JSON文件\n🤖 AI总结将以公开消息发送",
+    timestamp: new Date().toISOString(),
+  };
+
+  await interaction.editReply({
+    content: "处理完成！AI总结即将以公开消息发送...",
+    embeds: [completionEmbed],
+    files: [attachment],
+  });
+
+  const plainTextSummary = generatePlainTextSummary(
+    aiSummary,
+    channelInfo,
+    messages.length,
+  );
+  const summaryParts = splitLongText(plainTextSummary);
+
+  await interaction.channel.send(
+    `📋 **频道内容总结** (由 ${interaction.user.displayName} 发起)\n` +
+      `⏰ 时间范围: ${startTimeStr} 至 ${endTimeStr}`,
+  );
+
+  for (let i = 0; i < summaryParts.length; i++) {
+    const part = summaryParts[i];
+    const isLastPart = i === summaryParts.length - 1;
+
+    if (isLastPart && summaryParts.length > 1) {
+      try {
+        const textFile = await createSummaryTextFile(
+          aiSummary,
+          channelInfo,
+          messages.length,
+        );
+        const textAttachment = new AttachmentBuilder(textFile.filePath, {
+          name: textFile.fileName,
+        });
+
+        await interaction.channel.send({
+          content: `${part}\n\n📄 **完整总结已保存为文件**`,
+          files: [textAttachment],
+        });
+      } catch (fileError) {
+        console.warn("创建文本文件失败:", fileError);
+        await interaction.channel.send(part);
+      }
+    } else {
+      await interaction.channel.send(part);
+    }
+
+    if (i < summaryParts.length - 1) {
+      await new Promise((resolve) => setTimeout(resolve, 500));
+    }
+  }
+}
+
+async function execute(interaction) {
+  try {
+    const startTimeStr = interaction.options.getString("开始时间");
+    const endTimeStr = interaction.options.getString("结束时间");
+    const model = interaction.options.getString("模型");
+    const apiBaseUrl = interaction.options.getString("url");
+    const apiKey = interaction.options.getString("api");
+    const extraPrompt = interaction.options.getString("额外提示词");
+
+    await executeSummary(interaction, {
+      startTimeStr,
+      endTimeStr,
+      model,
+      apiBaseUrl,
+      apiKey,
+      extraPrompt,
+    });
+  } catch (error) {
+    console.error("频道总结命令执行失败:", error);
+
+    const errorMessage =
+      error.message.includes("不支持的时间格式") ||
+      error.message.includes("无效的时间") ||
+      error.message.includes("时间范围")
+        ? error.message
+        : "执行总结时发生错误，请稍后重试。";
+
+    try {
+      if (interaction.deferred || interaction.replied) {
+        await interaction.editReply(`❌ ${errorMessage}`);
+      } else {
+        await interaction.reply({
+          content: `❌ ${errorMessage}`,
+          ephemeral: true,
+        });
+      }
+    } catch (replyError) {
+      console.error("错误回复失败:", replyError);
+    }
+  }
+}
+
+module.exports = {
+  data,
+  execute,
+  executeSummary,
+  applyTimeDefaults,
+  formatDateTime,
+};

--- a/src/commands/summaryPreset.js
+++ b/src/commands/summaryPreset.js
@@ -1,0 +1,279 @@
+// src/modules/channelSummary/commands/summaryPreset.js
+
+const { SlashCommandBuilder, MessageFlags } = require("discord.js");
+const presetService = require("../services/presetService");
+const config = require("../config/presetConfig");
+const {
+  buildPresetEmbed,
+  buildPresetActionRow,
+} = require("../components/presetComponents");
+
+const data = new SlashCommandBuilder()
+  .setName("总结预设")
+  .setDescription("管理频道总结的参数预设")
+  .addSubcommand((sub) =>
+    sub
+      .setName("保存")
+      .setDescription("保存一组总结参数为预设")
+      .addStringOption((o) =>
+        o.setName("名称").setDescription("预设名称（唯一标识）").setRequired(true),
+      )
+      .addStringOption((o) =>
+        o.setName("开始时间").setDescription("默认开始时间 (YYYY-MM-DD HH:mm)").setRequired(false),
+      )
+      .addStringOption((o) =>
+        o.setName("结束时间").setDescription("默认结束时间 (YYYY-MM-DD HH:mm)").setRequired(false),
+      )
+      .addStringOption((o) =>
+        o.setName("模型").setDescription("默认模型名称").setRequired(false),
+      )
+      .addStringOption((o) =>
+        o.setName("url").setDescription("OpenAI 兼容接口地址").setRequired(false),
+      )
+      .addStringOption((o) =>
+        o.setName("api").setDescription("API Key").setRequired(false),
+      )
+      .addStringOption((o) =>
+        o.setName("额外提示词").setDescription("默认附加提示词").setRequired(false),
+      )
+      .addBooleanOption((o) =>
+        o.setName("公开").setDescription("是否全服共享此预设（默认仅自己可见）").setRequired(false),
+      ),
+  )
+  .addSubcommand((sub) =>
+    sub.setName("列表").setDescription("列出你可用的所有预设（含公开预设）"),
+  )
+  .addSubcommand((sub) =>
+    sub
+      .setName("删除")
+      .setDescription("删除你的一个预设")
+      .addStringOption((o) =>
+        o
+          .setName("名称")
+          .setDescription("要删除的预设名称")
+          .setRequired(true)
+          .setAutocomplete(true),
+      ),
+  )
+  .addSubcommand((sub) =>
+    sub
+      .setName("使用")
+      .setDescription("使用一个预设来执行频道总结")
+      .addStringOption((o) =>
+        o
+          .setName("名称")
+          .setDescription("要使用的预设名称")
+          .setRequired(true)
+          .setAutocomplete(true),
+      ),
+  );
+
+// ---- Autocomplete ----
+async function autocomplete(interaction) {
+  const subcommand = interaction.options.getSubcommand();
+  if (subcommand !== "删除" && subcommand !== "使用") return;
+
+  const focused = interaction.options.getFocused(true);
+  if (focused.name !== "名称") return;
+
+  const guildId = interaction.guild.id;
+  const userId = interaction.user.id;
+  const presets = await presetService.getUserPresets(guildId, userId);
+  const presetNames = Object.keys(presets);
+
+  const filtered = presetNames
+    .filter((n) => n.toLowerCase().includes(focused.value.toLowerCase()))
+    .slice(0, 25);
+
+  await interaction.respond(
+    filtered.map((n) => ({ name: n, value: n })),
+  );
+}
+
+// ---- 保存子命令 ----
+async function handleSave(interaction) {
+  const guildId = interaction.guild.id;
+  const userId = interaction.user.id;
+  const presetName = interaction.options.getString("名称");
+
+  const currentCount = await presetService.getPresetCount(guildId, userId);
+  if (currentCount >= config.MAX_PRESETS_PER_USER) {
+    return interaction.reply({
+      content: `❌ 预设数量已达上限（${config.MAX_PRESETS_PER_USER} 个），请先删除旧预设。`,
+      flags: MessageFlags.Ephemeral,
+    });
+  }
+
+  const isPublic = interaction.options.getBoolean("公开") || false;
+
+  const values = {
+    startTime: interaction.options.getString("开始时间") || "",
+    endTime: interaction.options.getString("结束时间") || "",
+    model: interaction.options.getString("模型") || "",
+    apiBaseUrl: interaction.options.getString("url") || "",
+    apiKey: interaction.options.getString("api") || "",
+    extraPrompt: interaction.options.getString("额外提示词") || "",
+    isPublic,
+  };
+
+  const isNew = await presetService.savePreset(guildId, userId, presetName, values);
+
+  return interaction.reply({
+    content: isNew
+      ? `✅ 预设「${presetName}」已保存（${isPublic ? "🌍 公开" : "🔒 私有"}）。`
+      : `✅ 预设「${presetName}」已更新（${isPublic ? "🌍 公开" : "🔒 私有"}）。`,
+    flags: MessageFlags.Ephemeral,
+  });
+}
+
+// ---- 列表子命令 ----
+async function handleList(interaction) {
+  const guildId = interaction.guild.id;
+  const userId = interaction.user.id;
+  const presets = await presetService.getUserPresets(guildId, userId);
+  const names = Object.keys(presets);
+
+  if (names.length === 0) {
+    return interaction.reply({
+      content: "📭 你还没有保存任何预设，且当前没有公开预设可用。使用 `/总结预设 保存` 来创建。",
+      flags: MessageFlags.Ephemeral,
+    });
+  }
+
+  const ownCount = names.filter((n) => presets[n].ownerId === userId).length;
+  const publicCount = names.length - ownCount;
+
+  const lines = names.map((n) => {
+    const p = presets[n];
+    const isOwn = p.ownerId === userId;
+    const icon = p.isPublic ? "🌍" : "🔒";
+    const ownerHint = isOwn ? "" : ` (by <@${p.ownerId}>)`;
+    return `• ${icon} **${n}**${ownerHint}`;
+  });
+
+  let footerText = `共 ${names.length} 个可用预设`;
+  if (ownCount > 0) footerText += `（私有 ${ownCount}`;
+  if (publicCount > 0) footerText += `${ownCount > 0 ? " + " : "（"}公开 ${publicCount}）`;
+  else if (ownCount > 0) footerText += "）";
+  footerText += ` | 私有上限 ${config.MAX_PRESETS_PER_USER}`;
+
+  const embed = {
+    color: 0x3498db,
+    title: "📋 可用频道总结预设",
+    description: lines.join("\n"),
+    footer: { text: footerText },
+  };
+
+  return interaction.reply({ embeds: [embed], flags: MessageFlags.Ephemeral });
+}
+
+// ---- 删除子命令 ----
+async function handleDelete(interaction) {
+  const guildId = interaction.guild.id;
+  const userId = interaction.user.id;
+  const presetName = interaction.options.getString("名称");
+
+  // 只能删除自己的预设
+  const preset = await presetService.getPreset(guildId, userId, presetName);
+  if (!preset) {
+    return interaction.reply({
+      content: `❌ 未找到预设「${presetName}」。`,
+      flags: MessageFlags.Ephemeral,
+    });
+  }
+
+  if (preset.isForeign) {
+    return interaction.reply({
+      content: `❌ 预设「${presetName}」是他人创建的公开预设，你无权删除。`,
+      flags: MessageFlags.Ephemeral,
+    });
+  }
+
+  const deleted = await presetService.deletePreset(guildId, userId, presetName);
+
+  return interaction.reply({
+    content: deleted
+      ? `✅ 预设「${presetName}」已删除。`
+      : `❌ 删除失败，未找到预设「${presetName}」。`,
+    flags: MessageFlags.Ephemeral,
+  });
+}
+
+// ---- 使用子命令 ----
+async function handleUse(interaction) {
+  const guildId = interaction.guild.id;
+  const userId = interaction.user.id;
+  const presetName = interaction.options.getString("名称");
+
+  const preset = await presetService.getPreset(guildId, userId, presetName);
+  if (!preset) {
+    return interaction.reply({
+      content: `❌ 未找到预设「${presetName}」。`,
+      flags: MessageFlags.Ephemeral,
+    });
+  }
+
+  const flowId = presetService.generateFlowId();
+  presetService.createFlow(flowId, {
+    guildId,
+    channelId: interaction.channelId,
+    userId,
+    presetName,
+    startTime: preset.startTime,
+    endTime: preset.endTime,
+    model: preset.model,
+    apiBaseUrl: preset.apiBaseUrl,
+    apiKey: preset.apiKey,
+    extraPrompt: preset.extraPrompt,
+    isPublic: preset.isPublic || false,
+    ownerId: preset.ownerId,
+    createdAt: new Date().toISOString(),
+  });
+
+  const embed = buildPresetEmbed(
+    {
+      startTime: preset.startTime,
+      endTime: preset.endTime,
+      model: preset.model,
+      apiBaseUrl: preset.apiBaseUrl,
+      apiKey: preset.apiKey,
+      extraPrompt: preset.extraPrompt,
+    },
+    presetName,
+    {
+      viewerUserId: userId,
+      ownerId: preset.ownerId,
+      isPublic: preset.isPublic,
+    },
+  );
+  const row = buildPresetActionRow(flowId);
+
+  return interaction.reply({
+    embeds: [embed],
+    components: [row],
+    flags: MessageFlags.Ephemeral,
+  });
+}
+
+// ---- 主执行入口 ----
+async function execute(interaction) {
+  const subcommand = interaction.options.getSubcommand();
+
+  switch (subcommand) {
+    case "保存":
+      return handleSave(interaction);
+    case "列表":
+      return handleList(interaction);
+    case "删除":
+      return handleDelete(interaction);
+    case "使用":
+      return handleUse(interaction);
+    default:
+      return interaction.reply({
+        content: "❌ 未知子命令。",
+        flags: MessageFlags.Ephemeral,
+      });
+  }
+}
+
+module.exports = { data, execute, autocomplete };

--- a/src/components/presetComponents.js
+++ b/src/components/presetComponents.js
@@ -1,0 +1,151 @@
+// src/modules/channelSummary/components/presetComponents.js
+
+const { TextInputStyle } = require("discord.js");
+
+/**
+ * 构建「修改参数」Modal — 仅 4 个业务字段（不含 url/api）
+ */
+function createEditPresetModal(flowId, presetValues) {
+  const { ModalBuilder, TextInputBuilder, ActionRowBuilder } = require("discord.js");
+
+  const modal = new ModalBuilder()
+    .setCustomId(`preset_edit_modal_${flowId}`)
+    .setTitle("修改预设参数");
+
+  const startTimeInput = new TextInputBuilder()
+    .setCustomId("preset_startTime")
+    .setLabel("开始时间 (YYYY-MM-DD HH:mm)")
+    .setStyle(TextInputStyle.Short)
+    .setValue(presetValues.startTime || "")
+    .setRequired(true);
+
+  const endTimeInput = new TextInputBuilder()
+    .setCustomId("preset_endTime")
+    .setLabel("结束时间 (YYYY-MM-DD HH:mm)")
+    .setStyle(TextInputStyle.Short)
+    .setValue(presetValues.endTime || "")
+    .setRequired(true);
+
+  const modelInput = new TextInputBuilder()
+    .setCustomId("preset_model")
+    .setLabel("模型 (留空使用默认)")
+    .setStyle(TextInputStyle.Short)
+    .setValue(presetValues.model || "")
+    .setRequired(false);
+
+  const extraPromptInput = new TextInputBuilder()
+    .setCustomId("preset_extraPrompt")
+    .setLabel("额外提示词 (可选)")
+    .setStyle(TextInputStyle.Paragraph)
+    .setValue(presetValues.extraPrompt || "")
+    .setRequired(false);
+
+  modal.addComponents(
+    new ActionRowBuilder().addComponents(startTimeInput),
+    new ActionRowBuilder().addComponents(endTimeInput),
+    new ActionRowBuilder().addComponents(modelInput),
+    new ActionRowBuilder().addComponents(extraPromptInput),
+  );
+
+  return modal;
+}
+
+/**
+ * 脱敏 API Key（所有者可见时）
+ */
+function maskApiKeyPartial(key) {
+  if (!key) return "（未设置）";
+  if (key.length <= 4) return "****";
+  return key.substring(0, 3) + "****" + key.substring(key.length - 2);
+}
+
+/**
+ * 构建预设参数展示 Embed
+ * @param {object} presetValues
+ * @param {string} presetName
+ * @param {object} [options]
+ * @param {string} [options.viewerUserId] - 当前查看者 ID
+ * @param {string} [options.ownerId] - 预设所有者 ID
+ * @param {boolean} [options.isPublic] - 是否公开预设
+ */
+function buildPresetEmbed(presetValues, presetName, options = {}) {
+  const { viewerUserId, ownerId, isPublic } = options;
+  const isOwner = !ownerId || viewerUserId === ownerId;
+
+  // API Key 显示策略：非所有者查看公用预设 → 完全脱敏；所有者 → 部分脱敏
+  let apiKeyDisplay;
+  if (!presetValues.apiKey) {
+    apiKeyDisplay = "（未设置）";
+  } else if (!isOwner && isPublic) {
+    apiKeyDisplay = "******";
+  } else {
+    apiKeyDisplay = maskApiKeyPartial(presetValues.apiKey);
+  }
+
+  const titleParts = [`📋 预设「${presetName}」参数确认`];
+  if (isPublic && !isOwner) {
+    titleParts.push(" 🌍（公开预设）");
+  }
+
+  const fields = [
+    { name: "开始时间", value: presetValues.startTime || "（未设置）", inline: true },
+    { name: "结束时间", value: presetValues.endTime || "（未设置）", inline: true },
+    { name: "模型", value: presetValues.model || "（使用默认模型）", inline: true },
+    { name: "API Base URL", value: presetValues.apiBaseUrl || "（使用默认地址）", inline: true },
+    { name: "API Key", value: apiKeyDisplay, inline: true },
+    { name: "额外提示词", value: presetValues.extraPrompt || "（无）", inline: false },
+  ];
+
+  if (isPublic && !isOwner && ownerId) {
+    fields.push({
+      name: "创建者",
+      value: `<@${ownerId}>`,
+      inline: true,
+    });
+  }
+
+  if (isPublic) {
+    fields.push({
+      name: "可见范围",
+      value: "🌍 全服共享",
+      inline: true,
+    });
+  }
+
+  return {
+    color: isPublic ? 0x2ecc71 : 0x3498db,
+    title: titleParts.join(""),
+    fields,
+    footer: { text: "请确认参数后点击下方按钮操作" },
+    timestamp: new Date().toISOString(),
+  };
+}
+
+/**
+ * 构建 3 按钮 ActionRow
+ */
+function buildPresetActionRow(flowId) {
+  const { ButtonBuilder, ButtonStyle, ActionRowBuilder } = require("discord.js");
+
+  return new ActionRowBuilder().addComponents(
+    new ButtonBuilder()
+      .setCustomId(`preset_confirm_${flowId}`)
+      .setLabel("确认执行")
+      .setStyle(ButtonStyle.Success),
+    new ButtonBuilder()
+      .setCustomId(`preset_edit_${flowId}`)
+      .setLabel("修改参数")
+      .setStyle(ButtonStyle.Primary),
+    new ButtonBuilder()
+      .setCustomId(`preset_cancel_${flowId}`)
+      .setLabel("取消")
+      .setStyle(ButtonStyle.Secondary),
+  );
+}
+
+module.exports = {
+  createEditPresetModal,
+  buildPresetEmbed,
+  buildPresetActionRow,
+  maskApiKey: maskApiKeyPartial,
+};

--- a/src/config/presetConfig.js
+++ b/src/config/presetConfig.js
@@ -1,0 +1,13 @@
+// src/modules/channelSummary/config/presetConfig.js
+
+const path = require("path");
+
+const DATA_DIR = path.join(process.cwd(), "data");
+
+module.exports = {
+  /** SQLite 数据库文件路径 */
+  PRESET_DB_PATH: path.join(DATA_DIR, "channelSummaryPresets.sqlite"),
+
+  /** 每用户私有预设数量上限 */
+  MAX_PRESETS_PER_USER: 25,
+};

--- a/src/config/summaryConfig.js
+++ b/src/config/summaryConfig.js
@@ -1,0 +1,48 @@
+// src/modules/channelSummary/config/summaryConfig.js
+
+module.exports = {
+    // 最大消息数量限制 (单次总结拉取上限)
+    MAX_MESSAGES: 3000,
+
+    // 默认时间范围（天）：当用户未提供开始时间时的回看天数
+    DEFAULT_TIME_RANGE_DAYS: 30,
+    
+    // 最大时间范围（天）
+    MAX_TIME_RANGE_DAYS: 30,
+    
+    // 临时文件保留时间（小时）
+    FILE_RETENTION_HOURS: process.env.SUMMARY_FILE_RETENTION_HOURS || 24,
+    
+    // Gemini API配置
+    GEMINI_MODEL: 'gemini-2.5-flash',
+    
+    //  OpenAI 兼容 API 配置
+    OPENAI_API_CONFIG: {
+        // 你的代理服务器 URL，从环境变量读取，若无则使用默认的 OpenAI 地址
+        BASE_URL: process.env.OPENAI_API_BASE_URL || 'https://api.openai.com/v1', 
+        
+        // 你的 API 密钥，从环境变量读取
+        API_KEY: process.env.OPENAI_API_KEY || 'your-api-key',
+        
+        // 你希望使用的模型，从环境变量读取，可设置默认值
+        MODEL: process.env.OPENAI_MODEL || 'gemini-2.5-pro'
+    },
+    
+    // 支持的时间格式
+    TIME_FORMATS: [
+        'YYYY-MM-DD',
+        'YYYYMMDD',
+        'YYYY-MM-DD HH:mm',
+        'MM-DD',
+        'HH:mm'
+    ],
+
+    // 总结显示配置
+    SUMMARY_DISPLAY: {
+        MAX_TOPICS: 5,
+        MAX_ACTIVE_USERS: 5,
+        MAX_OVERVIEW_LENGTH: 1000,
+        MAX_MESSAGE_LENGTH: 1900,  // Discord消息最大长度限制
+        MESSAGE_SEND_DELAY: 500    // 分段发送间隔(ms)
+    }
+};

--- a/src/services/aiSummaryService.js
+++ b/src/services/aiSummaryService.js
@@ -1,0 +1,222 @@
+// src/modules/channelSummary/services/aiSummaryService.js
+
+const { OpenAI } = require("openai");
+const config = require("../config/summaryConfig");
+
+let openAIClient;
+let openAIClientConfig = {
+  apiKey: null,
+  baseURL: null,
+};
+
+/**
+ * 初始化AI服务
+ */
+function initializeAI(apiConfig = {}) {
+  const resolvedApiKey = apiConfig.apiKey || config.OPENAI_API_CONFIG.API_KEY;
+  const resolvedBaseUrl =
+    apiConfig.apiBaseUrl || config.OPENAI_API_CONFIG.BASE_URL;
+
+  if (!resolvedApiKey) {
+    throw new Error("缺少 OPENAI_API_KEY 环境变量");
+  }
+
+  const shouldRecreateClient =
+    !openAIClient ||
+    openAIClientConfig.apiKey !== resolvedApiKey ||
+    openAIClientConfig.baseURL !== resolvedBaseUrl;
+
+  if (shouldRecreateClient) {
+    openAIClient = new OpenAI({
+      apiKey: resolvedApiKey,
+      baseURL: resolvedBaseUrl,
+    });
+    openAIClientConfig = {
+      apiKey: resolvedApiKey,
+      baseURL: resolvedBaseUrl,
+    };
+  }
+
+  return openAIClient;
+}
+
+/**
+ * 生成消息总结
+ */
+async function generateSummary(
+  messages,
+  channelInfo,
+  model = null,
+  options = {},
+) {
+  try {
+    const ai = initializeAI({
+      apiKey: options.apiKey,
+      apiBaseUrl: options.apiBaseUrl,
+    });
+
+    const promptMessages = buildOpenAISummaryPrompt(messages, channelInfo, {
+      extraPrompt: options.extraPrompt,
+    });
+
+    // 如果用户没有指定模型，则使用配置中的默认模型
+    const targetModel = model || config.OPENAI_API_CONFIG.MODEL;
+
+    const response = await ai.chat.completions.create({
+      model: targetModel,
+      messages: promptMessages,
+    });
+
+    const summaryText = response.choices[0]?.message?.content || "";
+
+    if (!summaryText) {
+      throw new Error("AI响应为空");
+    }
+
+    return parseSummaryResponse(summaryText, messages);
+  } catch (error) {
+    console.error("AI总结生成失败:", error);
+    return generateFallbackSummary(messages, channelInfo);
+  }
+}
+
+/**
+ * 构建OpenAI兼容的总结提示词
+ */
+function buildOpenAISummaryPrompt(messages, channelInfo, options = {}) {
+  const extraPrompt = (options.extraPrompt || "").trim();
+  const userMessages = {};
+  messages.forEach((msg) => {
+    const username = msg.author.display_name;
+    if (!userMessages[username]) {
+      userMessages[username] = [];
+    }
+    userMessages[username].push(msg.content);
+  });
+
+  const userSummaries = Object.entries(userMessages)
+    .map(([username, msgs]) => `${username}: ${msgs.join(" ")}`)
+    .join("\n\n");
+
+  const systemPrompt = `你是一个专业的Discord聊天分析助手。请对以下聊天记录进行详细分析，总结核心议题、关键信息以及每个主要参与用户的发言要点。
+
+请用中文提供详细的总结分析，并严格遵循以下格式：
+
+## 讨论概览
+（在这里对整体讨论的背景、氛围和主要议题进行概括性描述）
+
+## 用户发言分析
+（针对每个活跃用户，详细分析其发言的主要观点、关注重点。对于发言较少或无实质内容的用户可以简略或忽略）
+
+## 核心议题总结
+（在这里提炼出2-3个最主要的讨论话题和相关结论）
+
+## 关键信息汇总
+（在这里列出讨论中产生的任何重要决定、计划、约定或有价值的结论性信息）
+
+请确保分析客观、详细且有深度，能够准确反映出讨论的全貌。`;
+
+  const userPrompt = `频道信息：
+- 频道名称: ${channelInfo.name}
+- 消息数量: ${messages.length}
+- 参与用户数: ${Object.keys(userMessages).length}
+- 时间范围: ${new Date(channelInfo.timeRange.start).toLocaleString("zh-CN")} 到 ${new Date(channelInfo.timeRange.end).toLocaleString("zh-CN")}
+
+用户发言内容：
+${userSummaries}`;
+
+  const finalSystemPrompt = extraPrompt
+    ? `${systemPrompt}\n\n额外要求：\n${extraPrompt}`
+    : systemPrompt;
+
+  return [
+    { role: "system", content: finalSystemPrompt },
+    { role: "user", content: userPrompt },
+  ];
+}
+
+/**
+ * 解析AI响应
+ */
+function parseSummaryResponse(summaryText, messages) {
+  // 统计参与者信息
+  const userStats = {};
+  messages.forEach((msg) => {
+    const username = msg.author.display_name;
+    userStats[username] = (userStats[username] || 0) + 1;
+  });
+
+  const sortedUsers = Object.entries(userStats)
+    .sort(([, a], [, b]) => b - a)
+    .slice(0, 5)
+    .map(([name]) => name);
+
+  return {
+    overview: summaryText,
+    key_topics: extractTopics(summaryText),
+    participant_stats: {
+      most_active_users: sortedUsers,
+      total_participants: Object.keys(userStats).length,
+      message_distribution: userStats,
+    },
+    generated_at: new Date().toISOString(),
+  };
+}
+
+/**
+ * 从总结中提取话题（简单实现）
+ */
+function extractTopics(summaryText) {
+  // 这里可以实现更复杂的话题提取逻辑
+  const topics = [];
+  const lines = summaryText.split("\n");
+
+  for (const line of lines) {
+    if (line.includes("话题") || line.includes("主题")) {
+      const matches = line.match(/[：:]\s*(.+)/);
+      if (matches) {
+        topics.push(...matches[1].split(/[,，、]/));
+      }
+    }
+  }
+
+  return topics.slice(0, 5).map((topic) => topic.trim());
+}
+
+/**
+ * 生成备用总结（当AI失败时）
+ */
+function generateFallbackSummary(messages, channelInfo) {
+  const userStats = {};
+  const contentWords = [];
+
+  messages.forEach((msg) => {
+    const username = msg.author.display_name;
+    userStats[username] = (userStats[username] || 0) + 1;
+
+    // 简单的关键词提取
+    const words = msg.content.split(/\s+/).filter((word) => word.length > 2);
+    contentWords.push(...words);
+  });
+
+  const sortedUsers = Object.entries(userStats)
+    .sort(([, a], [, b]) => b - a)
+    .slice(0, 5)
+    .map(([name]) => name);
+
+  return {
+    overview: `本频道在指定时间段内共有 ${messages.length} 条消息，由 ${Object.keys(userStats).length} 位用户参与讨论。`,
+    key_topics: ["自动生成的总结暂不可用"],
+    participant_stats: {
+      most_active_users: sortedUsers,
+      total_participants: Object.keys(userStats).length,
+      message_distribution: userStats,
+    },
+    generated_at: new Date().toISOString(),
+  };
+}
+
+module.exports = {
+  generateSummary,
+  initializeAI,
+};

--- a/src/services/jsonExporter.js
+++ b/src/services/jsonExporter.js
@@ -1,0 +1,82 @@
+// src/modules/channelSummary/services/jsonExporter.js
+
+const fs = require('fs').promises;
+const path = require('path');
+
+/**
+ * 生成消息数据JSON（不包含AI总结）
+ */
+function generateMessagesJSON(channelInfo, messages) {
+    return {
+        export_info: {
+            channel_id: channelInfo.id,
+            channel_name: channelInfo.name,
+            channel_type: channelInfo.type,
+            time_range: {
+                start: channelInfo.timeRange.start,
+                end: channelInfo.timeRange.end
+            },
+            message_count: messages.length,
+            exported_at: new Date().toISOString(),
+            generator: "Discord Bot Channel Summary"
+        },
+        messages: messages
+    };
+}
+
+/**
+ * 保存JSON到临时文件
+ */
+async function saveToTempFile(messagesData, channelName) {
+    try {
+        // 创建临时目录
+        const tempDir = path.join(process.cwd(), 'temp', 'summaries');
+        await fs.mkdir(tempDir, { recursive: true });
+        
+        // 生成文件名
+        const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
+        const fileName = `${channelName}-messages-${timestamp}.json`;
+        const filePath = path.join(tempDir, fileName);
+        
+        // 写入文件
+        await fs.writeFile(filePath, JSON.stringify(messagesData, null, 2), 'utf8');
+        
+        return {
+            filePath,
+            fileName,
+            size: JSON.stringify(messagesData).length
+        };
+    } catch (error) {
+        throw new Error(`保存文件失败: ${error.message}`);
+    }
+}
+
+/**
+ * 清理过期的临时文件
+ */
+async function cleanupTempFiles(retentionHours = 24) {
+    try {
+        const tempDir = path.join(process.cwd(), 'temp', 'summaries');
+        const files = await fs.readdir(tempDir);
+        const now = Date.now();
+        
+        for (const file of files) {
+            const filePath = path.join(tempDir, file);
+            const stats = await fs.stat(filePath);
+            const ageHours = (now - stats.mtime.getTime()) / (1000 * 60 * 60);
+            
+            if (ageHours > retentionHours) {
+                await fs.unlink(filePath);
+                console.log(`清理过期总结文件: ${file}`);
+            }
+        }
+    } catch (error) {
+        console.warn('清理临时文件时出错:', error.message);
+    }
+}
+
+module.exports = {
+    generateMessagesJSON,
+    saveToTempFile,
+    cleanupTempFiles
+};

--- a/src/services/messageCollector.js
+++ b/src/services/messageCollector.js
@@ -1,0 +1,68 @@
+// src/modules/channelSummary/services/messageCollector.js
+
+const { Collection } = require('discord.js');
+
+/**
+ * 收集指定时间范围内的消息
+ */
+async function collectMessages(channel, startTime, endTime, maxMessages = 1000) {
+    const messages = [];
+    let lastMessageId = null;
+    let collected = 0;
+    
+    try {
+        while (collected < maxMessages) {
+            const fetchOptions = { 
+                limit: Math.min(100, maxMessages - collected),
+                before: lastMessageId 
+            };
+            
+            const fetchedMessages = await channel.messages.fetch(fetchOptions);
+            if (fetchedMessages.size === 0) break;
+            
+            for (const message of fetchedMessages.values()) {
+                const messageTime = message.createdAt;
+                
+                // 检查时间范围
+                if (messageTime < startTime) {
+                    return messages; // 已经超出时间范围，停止收集
+                }
+                
+                if (messageTime <= endTime) {
+                    messages.push(formatMessage(message));
+                    collected++;
+                }
+                
+                lastMessageId = message.id;
+            }
+        }
+        
+        return messages;
+    } catch (error) {
+        throw new Error(`收集消息时出错: ${error.message}`);
+    }
+}
+
+/**
+ * 格式化消息数据
+ */
+function formatMessage(message) {
+    return {
+        message_id: message.id,
+        author: {
+            display_name: message.member?.displayName || message.author.displayName || message.author.username,
+            user_id: message.author.id,
+            username: message.author.username
+        },
+        content: message.content || '[无文本内容]',
+        timestamp: message.createdAt.toISOString(),
+        has_attachments: message.attachments.size > 0,
+        attachment_count: message.attachments.size,
+        reply_to: message.reference?.messageId || null
+    };
+}
+
+module.exports = {
+    collectMessages,
+    formatMessage
+};

--- a/src/services/presetInteractionHandler.js
+++ b/src/services/presetInteractionHandler.js
@@ -1,0 +1,356 @@
+// src/modules/channelSummary/services/presetInteractionHandler.js
+
+const { MessageFlags, AttachmentBuilder } = require("discord.js");
+const presetService = require("./presetService");
+const {
+  buildPresetEmbed,
+  buildPresetActionRow,
+  createEditPresetModal,
+} = require("../components/presetComponents");
+const { parseTimeInput, validateTimeRange } = require("../utils/timeParser");
+const { collectMessages } = require("./messageCollector");
+const { generateSummary } = require("./aiSummaryService");
+const {
+  generateMessagesJSON,
+  saveToTempFile,
+  cleanupTempFiles,
+} = require("./jsonExporter");
+const {
+  generatePlainTextSummary,
+  splitLongText,
+  createSummaryTextFile,
+} = require("../utils/summaryFormatter");
+const summaryConfig = require("../config/summaryConfig");
+const {
+  applyTimeDefaults,
+  formatDateTime,
+} = require("../commands/summarizeChannel");
+
+/**
+ * 处理预设相关按钮点击
+ */
+async function handlePresetButton(interaction) {
+  const customId = interaction.customId;
+
+  if (customId.startsWith("preset_confirm_")) {
+    return handleConfirm(interaction);
+  } else if (customId.startsWith("preset_edit_")) {
+    return handleEdit(interaction);
+  } else if (customId.startsWith("preset_cancel_")) {
+    return handleCancel(interaction);
+  }
+}
+
+async function handleConfirm(interaction) {
+  const flowId = interaction.customId.replace("preset_confirm_", "");
+  const flow = presetService.getFlow(flowId);
+
+  if (!flow) {
+    return interaction.reply({
+      content: "❌ 该预设会话已过期，请重新使用 `/总结预设 使用`。",
+      flags: MessageFlags.Ephemeral,
+    });
+  }
+
+  presetService.deleteFlow(flowId);
+  await interaction.deferUpdate();
+  await runPresetSummary(interaction, flow);
+}
+
+async function runPresetSummary(interaction, flow) {
+  try {
+    let channel = interaction.channel;
+    if (!channel) {
+      try {
+        channel = await interaction.guild.channels.fetch(interaction.channelId);
+      } catch {
+        await interaction.editReply({
+          content: "❌ 无法获取频道信息。",
+          embeds: [],
+          components: [],
+        });
+        return;
+      }
+    }
+
+    // 应用时间默认值（预设可能未设置时间）
+    const { startTimeStr, endTimeStr, usedDefaultTime } = applyTimeDefaults(
+      flow.startTime,
+      flow.endTime,
+    );
+
+    const startTime = parseTimeInput(startTimeStr);
+    const endTime = parseTimeInput(endTimeStr);
+    validateTimeRange(startTime, endTime, summaryConfig.MAX_TIME_RANGE_DAYS);
+
+    let collectingMsg = "⏳ 开始收集消息...";
+    if (usedDefaultTime) {
+      collectingMsg += `\n> 📌 预设未设置完整时间参数，已自动拉取本频道近 ${summaryConfig.DEFAULT_TIME_RANGE_DAYS} 天内的消息（上限 ${summaryConfig.MAX_MESSAGES} 条）进行总结。`;
+    }
+    await interaction.editReply({
+      content: collectingMsg,
+      embeds: [],
+      components: [],
+    });
+
+    const messages = await collectMessages(
+      channel,
+      startTime,
+      endTime,
+      summaryConfig.MAX_MESSAGES,
+    );
+
+    if (messages.length === 0) {
+      return await interaction.editReply({
+        content: "❌ 在指定时间范围内没有找到任何消息。",
+        embeds: [],
+        components: [],
+      });
+    }
+
+    await interaction.editReply({
+      content: `📊 收集到 ${messages.length} 条消息，正在生成AI总结...`,
+      embeds: [],
+      components: [],
+    });
+
+    const channelInfo = {
+      id: channel.id,
+      name: channel.name || "未命名频道",
+      type: channel.type,
+      timeRange: {
+        start: startTime.toISOString(),
+        end: endTime.toISOString(),
+      },
+    };
+
+    const aiSummary = await generateSummary(
+      messages,
+      channelInfo,
+      flow.model || null,
+      {
+        apiBaseUrl: flow.apiBaseUrl || null,
+        apiKey: flow.apiKey || null,
+        extraPrompt: flow.extraPrompt || null,
+      },
+    );
+
+    await interaction.editReply({
+      content: "📝 正在生成文件和总结...",
+      embeds: [],
+      components: [],
+    });
+
+    const messagesData = generateMessagesJSON(channelInfo, messages);
+    const fileInfo = await saveToTempFile(messagesData, channelInfo.name);
+
+    const attachment = new AttachmentBuilder(fileInfo.filePath, {
+      name: fileInfo.fileName,
+    });
+
+    cleanupTempFiles(summaryConfig.FILE_RETENTION_HOURS).catch(console.warn);
+
+    const completionEmbed = {
+      color: 0x00ff00,
+      title: "✅ 频道内容总结完成",
+      fields: [
+        { name: "频道", value: channelInfo.name, inline: true },
+        { name: "消息数量", value: messages.length.toString(), inline: true },
+        {
+          name: "参与用户",
+          value: aiSummary.participant_stats.total_participants.toString(),
+          inline: true,
+        },
+        {
+          name: "时间范围",
+          value: `${startTimeStr} 至 ${endTimeStr}`,
+          inline: false,
+        },
+        {
+          name: "文件大小",
+          value: `${Math.round(fileInfo.size / 1024)} KB`,
+          inline: true,
+        },
+      ],
+      description: "📁 消息数据已导出到JSON文件\n🤖 AI总结将以公开消息发送",
+      timestamp: new Date().toISOString(),
+    };
+
+    await interaction.editReply({
+      content: "处理完成！AI总结即将以公开消息发送...",
+      embeds: [completionEmbed],
+      files: [attachment],
+    });
+
+    const plainTextSummary = generatePlainTextSummary(
+      aiSummary,
+      channelInfo,
+      messages.length,
+    );
+    const summaryParts = splitLongText(plainTextSummary);
+
+    await interaction.channel.send(
+      `📋 **频道内容总结** (由 ${interaction.user.displayName} 发起)\n` +
+        `⏰ 时间范围: ${startTimeStr} 至 ${endTimeStr}`,
+    );
+
+    for (let i = 0; i < summaryParts.length; i++) {
+      const part = summaryParts[i];
+      const isLastPart = i === summaryParts.length - 1;
+
+      if (isLastPart && summaryParts.length > 1) {
+        try {
+          const textFile = await createSummaryTextFile(
+            aiSummary,
+            channelInfo,
+            messages.length,
+          );
+          const textAttachment = new AttachmentBuilder(textFile.filePath, {
+            name: textFile.fileName,
+          });
+          await interaction.channel.send({
+            content: `${part}\n\n📄 **完整总结已保存为文件**`,
+            files: [textAttachment],
+          });
+        } catch (fileError) {
+          console.warn("创建文本文件失败:", fileError);
+          await interaction.channel.send(part);
+        }
+      } else {
+        await interaction.channel.send(part);
+      }
+
+      if (i < summaryParts.length - 1) {
+        await new Promise((resolve) => setTimeout(resolve, 500));
+      }
+    }
+  } catch (error) {
+    console.error("预设总结执行失败:", error);
+    const errorMessage =
+      error.message.includes("不支持的时间格式") ||
+      error.message.includes("无效的时间") ||
+      error.message.includes("时间范围")
+        ? error.message
+        : "执行总结时发生错误，请稍后重试。";
+    try {
+      await interaction.editReply({
+        content: `❌ ${errorMessage}`,
+        embeds: [],
+        components: [],
+      });
+    } catch {
+      try {
+        await interaction.followUp({
+          content: `❌ ${errorMessage}`,
+          flags: MessageFlags.Ephemeral,
+        });
+      } catch {
+        // 忽略
+      }
+    }
+  }
+}
+
+async function handleEdit(interaction) {
+  const flowId = interaction.customId.replace("preset_edit_", "");
+  const flow = presetService.getFlow(flowId);
+
+  if (!flow) {
+    return interaction.reply({
+      content: "❌ 该预设会话已过期。",
+      flags: MessageFlags.Ephemeral,
+    });
+  }
+
+  const modal = createEditPresetModal(flowId, {
+    startTime: flow.startTime,
+    endTime: flow.endTime,
+    model: flow.model,
+    extraPrompt: flow.extraPrompt,
+  });
+
+  await interaction.showModal(modal);
+}
+
+async function handleCancel(interaction) {
+  const flowId = interaction.customId.replace("preset_cancel_", "");
+  presetService.deleteFlow(flowId);
+
+  if (interaction.message) {
+    await interaction.update({
+      content: "❌ 已取消预设操作。",
+      embeds: [],
+      components: [],
+    });
+  } else {
+    await interaction.reply({
+      content: "❌ 已取消预设操作。",
+      flags: MessageFlags.Ephemeral,
+    });
+  }
+}
+
+/**
+ * 处理预设编辑 Modal 提交
+ */
+async function handlePresetModal(interaction) {
+  const flowId = interaction.customId.replace("preset_edit_modal_", "");
+  const flow = presetService.getFlow(flowId);
+
+  if (!flow) {
+    return interaction.reply({
+      content: "❌ 该预设会话已过期。",
+      flags: MessageFlags.Ephemeral,
+    });
+  }
+
+  const newStartTime = interaction.fields.getTextInputValue("preset_startTime");
+  const newEndTime = interaction.fields.getTextInputValue("preset_endTime");
+  const newModel = interaction.fields.getTextInputValue("preset_model");
+  const newExtraPrompt = interaction.fields.getTextInputValue("preset_extraPrompt");
+
+  presetService.updateFlowValues(flowId, {
+    startTime: newStartTime,
+    endTime: newEndTime,
+    model: newModel,
+    extraPrompt: newExtraPrompt,
+  });
+
+  const updatedFlow = presetService.getFlow(flowId);
+
+  const embed = buildPresetEmbed(
+    {
+      startTime: updatedFlow.startTime,
+      endTime: updatedFlow.endTime,
+      model: updatedFlow.model,
+      apiBaseUrl: updatedFlow.apiBaseUrl,
+      apiKey: updatedFlow.apiKey,
+      extraPrompt: updatedFlow.extraPrompt,
+    },
+    updatedFlow.presetName,
+    {
+      viewerUserId: interaction.user.id,
+      ownerId: updatedFlow.ownerId,
+      isPublic: updatedFlow.isPublic,
+    },
+  );
+  const row = buildPresetActionRow(flowId);
+
+  try {
+    await interaction.update({
+      embeds: [embed],
+      components: [row],
+    });
+  } catch {
+    await interaction.reply({
+      embeds: [embed],
+      components: [row],
+      flags: MessageFlags.Ephemeral,
+    });
+  }
+}
+
+module.exports = {
+  handlePresetButton,
+  handlePresetModal,
+};

--- a/src/services/presetService.js
+++ b/src/services/presetService.js
@@ -1,0 +1,240 @@
+// src/modules/channelSummary/services/presetService.js
+
+const fs = require("fs");
+const path = require("path");
+const crypto = require("crypto");
+const Database = require("better-sqlite3");
+const config = require("../config/presetConfig");
+
+// ---- SQLite 初始化 ----
+const dir = path.dirname(config.PRESET_DB_PATH);
+if (!fs.existsSync(dir)) {
+  fs.mkdirSync(dir, { recursive: true });
+}
+
+const db = new Database(config.PRESET_DB_PATH);
+db.pragma("journal_mode = WAL");
+db.pragma("foreign_keys = ON");
+
+db.exec(`
+  CREATE TABLE IF NOT EXISTS presets (
+    guild_id   TEXT NOT NULL,
+    user_id    TEXT NOT NULL,
+    name       TEXT NOT NULL,
+    start_time TEXT DEFAULT '',
+    end_time   TEXT DEFAULT '',
+    model      TEXT DEFAULT '',
+    api_base_url TEXT DEFAULT '',
+    api_key    TEXT DEFAULT '',
+    extra_prompt TEXT DEFAULT '',
+    is_public  INTEGER DEFAULT 0,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    PRIMARY KEY (guild_id, user_id, name)
+  );
+`);
+
+// ---- 预设 CRUD ----
+
+function rowToPreset(row) {
+  if (!row) return null;
+  return {
+    startTime: row.start_time || "",
+    endTime: row.end_time || "",
+    model: row.model || "",
+    apiBaseUrl: row.api_base_url || "",
+    apiKey: row.api_key || "",
+    extraPrompt: row.extra_prompt || "",
+    isPublic: row.is_public === 1,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+    ownerId: row.user_id,
+    guildId: row.guild_id,
+  };
+}
+
+/**
+ * 获取用户可见的所有预设（自己的私有 + 全服公用）
+ */
+function getUserPresets(guildId, userId) {
+  const rows = db
+    .prepare(
+      `SELECT * FROM presets
+       WHERE guild_id = ? AND (user_id = ? OR is_public = 1)
+       ORDER BY is_public DESC, name ASC`,
+    )
+    .all(guildId, userId);
+
+  const result = {};
+  for (const row of rows) {
+    result[row.name] = rowToPreset(row);
+  }
+  return result;
+}
+
+/**
+ * 获取单个预设。优先返回自己的；其次返回公用预设（非自己的公用预设会附加 isForeign 标记）。
+ */
+function getPreset(guildId, userId, presetName) {
+  // 优先查自己的
+  let row = db
+    .prepare(
+      `SELECT * FROM presets WHERE guild_id = ? AND user_id = ? AND name = ?`,
+    )
+    .get(guildId, userId, presetName);
+
+  if (!row) {
+    // 查公用预设（非自己）
+    row = db
+      .prepare(
+        `SELECT * FROM presets
+         WHERE guild_id = ? AND name = ? AND is_public = 1 AND user_id != ?`,
+      )
+      .get(guildId, presetName, userId);
+
+    if (!row) return null;
+
+    const preset = rowToPreset(row);
+    preset.isForeign = true; // 标记为他人创建的公用预设
+    return preset;
+  }
+
+  return rowToPreset(row);
+}
+
+/**
+ * 保存/更新预设。返回 { isNew: boolean }。
+ */
+function savePreset(guildId, userId, presetName, values) {
+  const existing = db
+    .prepare(
+      `SELECT 1 FROM presets WHERE guild_id = ? AND user_id = ? AND name = ?`,
+    )
+    .get(guildId, userId, presetName);
+
+  const isNew = !existing;
+  const now = new Date().toISOString();
+
+  const isPublic = values.isPublic ? 1 : 0;
+
+  if (isNew) {
+    db.prepare(
+      `INSERT INTO presets
+         (guild_id, user_id, name, start_time, end_time, model, api_base_url,
+          api_key, extra_prompt, is_public, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    ).run(
+      guildId,
+      userId,
+      presetName,
+      values.startTime || "",
+      values.endTime || "",
+      values.model || "",
+      values.apiBaseUrl || "",
+      values.apiKey || "",
+      values.extraPrompt || "",
+      isPublic,
+      now,
+      now,
+    );
+  } else {
+    const sets = [];
+    const params = [];
+    for (const [col, val] of Object.entries({
+      start_time: values.startTime || "",
+      end_time: values.endTime || "",
+      model: values.model || "",
+      api_base_url: values.apiBaseUrl || "",
+      api_key: values.apiKey || "",
+      extra_prompt: values.extraPrompt || "",
+    })) {
+      sets.push(`${col} = ?`);
+      params.push(val);
+    }
+    sets.push("is_public = ?");
+    params.push(isPublic);
+    sets.push("updated_at = ?");
+    params.push(now);
+    params.push(guildId, userId, presetName);
+
+    db.prepare(
+      `UPDATE presets SET ${sets.join(", ")} WHERE guild_id = ? AND user_id = ? AND name = ?`,
+    ).run(...params);
+  }
+
+  return isNew;
+}
+
+/**
+ * 删除一个预设（仅所有者可删除）。返回 true/false。
+ */
+function deletePreset(guildId, userId, presetName) {
+  const info = db
+    .prepare(
+      `DELETE FROM presets WHERE guild_id = ? AND user_id = ? AND name = ?`,
+    )
+    .run(guildId, userId, presetName);
+  return info.changes > 0;
+}
+
+/**
+ * 获取用户自己的预设数量（仅私有预设）
+ */
+function getPresetCount(guildId, userId) {
+  const row = db
+    .prepare(
+      `SELECT COUNT(*) AS cnt FROM presets WHERE guild_id = ? AND user_id = ?`,
+    )
+    .get(guildId, userId);
+  return row ? row.cnt : 0;
+}
+
+// ---- Flow 会话管理（内存） ----
+
+const flowMap = new Map();
+
+function generateFlowId() {
+  return crypto.randomUUID();
+}
+
+function createFlow(flowId, data) {
+  flowMap.set(flowId, { ...data, flowId });
+}
+
+function getFlow(flowId) {
+  return flowMap.get(flowId) || null;
+}
+
+function updateFlowValues(flowId, updates) {
+  const flow = flowMap.get(flowId);
+  if (!flow) return null;
+  Object.assign(flow, updates);
+  return flow;
+}
+
+function deleteFlow(flowId) {
+  flowMap.delete(flowId);
+}
+
+setInterval(() => {
+  const cutoff = Date.now() - 30 * 60 * 1000;
+  for (const [id, flow] of flowMap) {
+    if (flow.createdAt && new Date(flow.createdAt).getTime() < cutoff) {
+      flowMap.delete(id);
+    }
+  }
+}, 5 * 60 * 1000);
+
+module.exports = {
+  getUserPresets,
+  getPreset,
+  savePreset,
+  deletePreset,
+  getPresetCount,
+  createFlow,
+  getFlow,
+  updateFlowValues,
+  deleteFlow,
+  generateFlowId,
+  flowMap,
+};


### PR DESCRIPTION
📖 改动说明：
本次提交是对现有频道总结功能的全面重构与增强，旨在解决用户配置繁琐、隐私泄露风险及总结覆盖度不足的问题。
1. 核心逻辑深度优化**
扩大扫描范围：将默认总结的消息拉取上限从原有的限制提升至 3000 条消息或 过去 30 天，确保长周期、高活跃频道的总结质量。
架构解耦：重构了 executeSummary`执行管线，使其与指令触发逻辑解耦，提升了代码的复用性和可维护性。
2. 全新的预设管理系统 (Preset System)
持久化存储**：引入 SQLite 数据库，支持用户保存多套自定义总结配置（包括模型选择、自定义 Prompt、参数等）。
全套 CRUD 交互：通过 `/总结预设` 系列子指令，实现预设的保存、列表展示、快速删除及一键调用。
3. **多维度的隐私与安全保护**
公私有化机制：新增预设的is_public属性。用户可将含有敏感信息（如私有 API Key）的预设设为“私有”，仅限本人可见。
脱敏处理：在公开展示预设列表时，对 API Key 等敏感字符串进行自动脱敏掩码处理，杜绝泄露风险。
 4.交互体验 (UX) 升级
现代交互路由：全面接入 Discord 的Modal (弹窗)录入方式，取代繁琐的参数输入。
动态组件响应：重构了按钮 (Button) 与交互组件的路由逻辑，支持更复杂的流式会话管理。

🛠️ 技术清单 (Technical Changes)：
数据库层：新增 presets`表及相关索引。
服务层：新增 presetService.js`(核心逻辑) 与 presetInteractionHandler.js(交互管线)。
组件层：封装了 presetComponents.js用于构建高性能的 Embed 和 ActionRow。
配置层：统一了总结逻辑的常量管理 summaryConfig.js。

✅ 测试报告：
兼容性测：已在dc服务器环境完成多轮回归测试，确保新旧总结逻辑平稳过渡。
交互测试：覆盖了所有按钮分支及弹窗异常处理逻辑。