### PR TITLE
feat: 频道总结预设系统 公私有化管理、三层权限架构、管理面板与默认时间优化

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -15,6 +15,9 @@ OPENAI_API_BASE_URL=https://api.openai.com/v1
 OPENAI_API_KEY=your_openai_api_key
 OPENAI_MODEL=gemini-2.5-pro
 
+# 总结模块的最高管理员身份组 ID
+SUMMARY_ADMIN_ROLE_IDS=
+
 # 身份组同步系统（可选）
 # 多链路 JSON 配置示例：
 # ROLE_SYNC_LINKS_JSON=[{"linkId":"main_to_sub1","sourceGuildId":"111111111111111111","targetGuildId":"222222222222222222","enabled":true,"defaultConflictPolicy":"source_of_truth_main"}]

--- a/src/core/events/interactionCreate.js
+++ b/src/core/events/interactionCreate.js
@@ -79,6 +79,13 @@ const { processEditProposal, processEditProposalSubmission } = require('../../mo
 const { checkFormPermission, getFormPermissionDeniedMessage } = require('../../core/utils/permissionManager');
 const { getFormPermissionSettings } = require('../../core/utils/database');
 
+// 频道总结预设交互处理
+const {
+  handlePresetButton,
+  handlePresetModal,
+  handlePresetSelect,
+} = require('../../modules/channelSummary/services/presetInteractionHandler');
+
 const INTERACTION_DEBUG_LOG = String(process.env.INTERACTION_DEBUG_LOG || '').toLowerCase() === 'true';
 
 const {
@@ -556,7 +563,12 @@ async function interactionCreateHandler(interaction) {
                 const { handleInviteRequest } = require('../../modules/controlledInvite/services/inviteService');
                 await handleInviteRequest(interaction);
             }
-            
+
+            // === 频道总结预设按钮处理 ===
+            if (interaction.customId.startsWith('preset_')) {
+                await handlePresetButton(interaction);
+            }
+
             return;
         }
         
@@ -628,6 +640,10 @@ async function interactionCreateHandler(interaction) {
             } else if (interaction.customId.startsWith('admin_add_role_modal_') || interaction.customId.startsWith('admin_edit_role_modal_')) {
                 await handleModalSubmit(interaction);
             }
+            // === 频道总结预设 Modal 处理 ===
+            else if (interaction.customId.startsWith('preset_edit_modal_')) {
+                await handlePresetModal(interaction);
+            }
             return;
         }
         
@@ -684,6 +700,10 @@ async function interactionCreateHandler(interaction) {
                 await handleRoleSelectForRemove(interaction);
             } else if (interaction.customId === 'admin_edit_role_select') {
                 await handleRoleSelectForEdit(interaction);
+            }
+            // === 频道总结预设选择菜单处理 ===
+            else if (interaction.customId.startsWith('preset_panel_')) {
+                await handlePresetSelect(interaction);
             }
             return;
         }

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -114,6 +114,7 @@ const cleanupManagerCommand = require('../modules/autoCleanup/commands/cleanupMa
 
 // 频道总结系统命令
 const summarizeChannelCommand = require('../modules/channelSummary/commands/summarizeChannel');
+const summaryPresetCommand = require('../modules/channelSummary/commands/summaryPreset');
 
 // 投票系统命令
 const createVoteCommand = require('../modules/voting/commands/createVote');
@@ -330,6 +331,7 @@ client.commands.set(deleteRebuiltMessageCommand.data.name, deleteRebuiltMessageC
 
 // 频道总结系统命令
 client.commands.set(summarizeChannelCommand.data.name, summarizeChannelCommand);
+client.commands.set(summaryPresetCommand.data.name, summaryPresetCommand);
 
 // 投票系统命令
 client.commands.set(createVoteCommand.data.name, createVoteCommand);

--- a/src/modules/channelSummary/commands/summarizeChannel.js
+++ b/src/modules/channelSummary/commands/summarizeChannel.js
@@ -22,20 +22,56 @@ const {
 } = require("../utils/summaryFormatter");
 const config = require("../config/summaryConfig");
 
+/**
+ * 格式化 Date → "YYYY-MM-DD HH:mm"
+ */
+function formatDateTime(date) {
+  const y = date.getFullYear();
+  const m = String(date.getMonth() + 1).padStart(2, "0");
+  const d = String(date.getDate()).padStart(2, "0");
+  const hh = String(date.getHours()).padStart(2, "0");
+  const mm = String(date.getMinutes()).padStart(2, "0");
+  return `${y}-${m}-${d} ${hh}:${mm}`;
+}
+
+/**
+ * 为未提供的时间参数填充默认值。
+ * 返回 { startTimeStr, endTimeStr, usedDefaultTime }
+ */
+function applyTimeDefaults(startTimeStr, endTimeStr) {
+  const now = new Date();
+  let usedDefaultTime = false;
+
+  let resolvedEnd = endTimeStr;
+  let resolvedStart = startTimeStr;
+
+  if (!resolvedEnd || !resolvedEnd.trim()) {
+    resolvedEnd = formatDateTime(now);
+    usedDefaultTime = true;
+  }
+  if (!resolvedStart || !resolvedStart.trim()) {
+    const thirtyDaysAgo = new Date(now.getTime() - config.DEFAULT_TIME_RANGE_DAYS * 24 * 60 * 60 * 1000);
+    resolvedStart = formatDateTime(thirtyDaysAgo);
+    usedDefaultTime = true;
+  }
+
+  return { startTimeStr: resolvedStart, endTimeStr: resolvedEnd, usedDefaultTime };
+}
+
 const data = new SlashCommandBuilder()
   .setName("总结频道内容")
   .setDescription("总结指定时间段内的频道消息")
   .addStringOption((option) =>
     option
       .setName("开始时间")
-      .setDescription("开始时间 (格式: YYYY-MM-DD HH:mm 或 YYYY-MM-DD)")
-      .setRequired(true),
+      .setDescription("开始时间 (YYYY-MM-DD HH:mm)，不填默认 30 天前")
+      .setRequired(false),
   )
   .addStringOption((option) =>
     option
       .setName("结束时间")
-      .setDescription("结束时间 (格式: YYYY-MM-DD HH:mm 或 YYYY-MM-DD)")
-      .setRequired(true),
+      .setDescription("结束时间 (YYYY-MM-DD HH:mm)，不填默认当前时间")
+      .setRequired(false),
   )
   .addStringOption((option) =>
     option
@@ -61,215 +97,225 @@ const data = new SlashCommandBuilder()
       .setDescription("可选，附加在默认系统提示词之后")
       .setRequired(false),
   );
-// .setDefaultMemberPermissions(PermissionFlagsBits.ManageMessages); // 注释了权限要求，需要使用时候取消注释
+
+/**
+ * 执行频道总结的核心逻辑，可被 slash command 和 preset flow 共同调用。
+ * @param {Interaction} interaction
+ * @param {object} params
+ * @param {string|null} params.startTimeStr
+ * @param {string|null} params.endTimeStr
+ * @param {string|null} params.model
+ * @param {string|null} params.apiBaseUrl
+ * @param {string|null} params.apiKey
+ * @param {string|null} params.extraPrompt
+ * @param {object} [params.channel]
+ */
+async function executeSummary(interaction, params) {
+  if (!interaction || !interaction.isRepliable()) {
+    console.error("无效的交互对象");
+    return;
+  }
+
+  let channel = params.channel || interaction.channel;
+  if (!channel) {
+    try {
+      channel = await interaction.guild.channels.fetch(interaction.channelId);
+    } catch (error) {
+      console.error("无法获取频道信息:", error);
+      return;
+    }
+  }
+
+  try {
+    await interaction.deferReply({ ephemeral: true });
+  } catch (deferError) {
+    console.error("Defer回复失败:", deferError);
+    try {
+      await interaction.reply({
+        content: "❌ 交互已过期，请重新尝试命令。",
+        ephemeral: true,
+      });
+    } catch (replyError) {
+      console.error("直接回复也失败:", replyError);
+    }
+    return;
+  }
+
+  if (!channel) {
+    return await interaction.editReply(
+      "❌ 无法获取频道信息，请确保在正确的频道中使用此命令。",
+    );
+  }
+
+  const isValidChannel =
+    channel.isTextBased() ||
+    (channel.isThread && channel.isThread()) ||
+    channel.type === 0 ||
+    channel.type === 11;
+
+  if (!isValidChannel) {
+    return await interaction.editReply(
+      "❌ 此命令只能在文字频道或线程中使用。",
+    );
+  }
+
+  const { model, apiBaseUrl, apiKey, extraPrompt } = params;
+
+  // 应用时间默认值
+  const { startTimeStr, endTimeStr, usedDefaultTime } = applyTimeDefaults(
+    params.startTimeStr,
+    params.endTimeStr,
+  );
+
+  const startTime = parseTimeInput(startTimeStr);
+  const endTime = parseTimeInput(endTimeStr);
+  validateTimeRange(startTime, endTime, config.MAX_TIME_RANGE_DAYS);
+
+  // 进度消息：若使用了默认时间，追加说明
+  let collectingMsg = "⏳ 开始收集消息...";
+  if (usedDefaultTime) {
+    collectingMsg += `\n> 📌 未检测到时间参数，已自动拉取本频道近 ${config.DEFAULT_TIME_RANGE_DAYS} 天内的消息（上限 ${config.MAX_MESSAGES} 条）进行总结。`;
+  }
+  await interaction.editReply(collectingMsg);
+
+  const messages = await collectMessages(
+    channel,
+    startTime,
+    endTime,
+    config.MAX_MESSAGES,
+  );
+
+  if (messages.length === 0) {
+    return await interaction.editReply(
+      "❌ 在指定时间范围内没有找到任何消息。",
+    );
+  }
+
+  await interaction.editReply(
+    `📊 收集到 ${messages.length} 条消息，正在生成AI总结...`,
+  );
+
+  const channelInfo = {
+    id: channel.id,
+    name: channel.name || "未命名频道",
+    type: channel.type,
+    timeRange: {
+      start: startTime.toISOString(),
+      end: endTime.toISOString(),
+    },
+  };
+
+  const aiSummary = await generateSummary(messages, channelInfo, model, {
+    apiBaseUrl,
+    apiKey,
+    extraPrompt,
+  });
+
+  await interaction.editReply("📝 正在生成文件和总结...");
+
+  const messagesData = generateMessagesJSON(channelInfo, messages);
+  const fileInfo = await saveToTempFile(messagesData, channelInfo.name);
+
+  const attachment = new AttachmentBuilder(fileInfo.filePath, {
+    name: fileInfo.fileName,
+  });
+
+  cleanupTempFiles(config.FILE_RETENTION_HOURS).catch(console.warn);
+
+  const completionEmbed = {
+    color: 0x00ff00,
+    title: "✅ 频道内容总结完成",
+    fields: [
+      { name: "频道", value: channelInfo.name, inline: true },
+      { name: "消息数量", value: messages.length.toString(), inline: true },
+      {
+        name: "参与用户",
+        value: aiSummary.participant_stats.total_participants.toString(),
+        inline: true,
+      },
+      {
+        name: "时间范围",
+        value: `${startTimeStr} 至 ${endTimeStr}`,
+        inline: false,
+      },
+      {
+        name: "文件大小",
+        value: `${Math.round(fileInfo.size / 1024)} KB`,
+        inline: true,
+      },
+    ],
+    description: "📁 消息数据已导出到JSON文件\n🤖 AI总结将以公开消息发送",
+    timestamp: new Date().toISOString(),
+  };
+
+  await interaction.editReply({
+    content: "处理完成！AI总结即将以公开消息发送...",
+    embeds: [completionEmbed],
+    files: [attachment],
+  });
+
+  const plainTextSummary = generatePlainTextSummary(
+    aiSummary,
+    channelInfo,
+    messages.length,
+  );
+  const summaryParts = splitLongText(plainTextSummary);
+
+  await interaction.channel.send(
+    `📋 **频道内容总结** (由 ${interaction.user.displayName} 发起)\n` +
+      `⏰ 时间范围: ${startTimeStr} 至 ${endTimeStr}`,
+  );
+
+  for (let i = 0; i < summaryParts.length; i++) {
+    const part = summaryParts[i];
+    const isLastPart = i === summaryParts.length - 1;
+
+    if (isLastPart && summaryParts.length > 1) {
+      try {
+        const textFile = await createSummaryTextFile(
+          aiSummary,
+          channelInfo,
+          messages.length,
+        );
+        const textAttachment = new AttachmentBuilder(textFile.filePath, {
+          name: textFile.fileName,
+        });
+
+        await interaction.channel.send({
+          content: `${part}\n\n📄 **完整总结已保存为文件**`,
+          files: [textAttachment],
+        });
+      } catch (fileError) {
+        console.warn("创建文本文件失败:", fileError);
+        await interaction.channel.send(part);
+      }
+    } else {
+      await interaction.channel.send(part);
+    }
+
+    if (i < summaryParts.length - 1) {
+      await new Promise((resolve) => setTimeout(resolve, 500));
+    }
+  }
+}
 
 async function execute(interaction) {
   try {
-    // 1. 添加更强的错误处理和验证
-    // 首先验证interaction和channel的有效性
-    if (!interaction || !interaction.isRepliable()) {
-      console.error("无效的交互对象");
-      return;
-    }
-
-    // 2. 改进channel获取逻辑，处理子区情况
-    let channel = interaction.channel;
-
-    // 如果在子区中，可能需要获取父频道
-    if (!channel) {
-      // 尝试从guild获取频道
-      try {
-        channel = await interaction.guild.channels.fetch(interaction.channelId);
-      } catch (error) {
-        console.error("无法获取频道信息:", error);
-        return;
-      }
-    }
-
-    // 3. 立即defer回复，避免3秒超时
-    try {
-      await interaction.deferReply({ ephemeral: true });
-    } catch (deferError) {
-      console.error("Defer回复失败:", deferError);
-      // 如果defer失败，尝试直接回复
-      try {
-        await interaction.reply({
-          content: "❌ 交互已过期，请重新尝试命令。",
-          ephemeral: true,
-        });
-      } catch (replyError) {
-        console.error("直接回复也失败:", replyError);
-      }
-      return;
-    }
-
-    // 4. 检查频道类型（添加null检查）
-    if (!channel) {
-      return await interaction.editReply(
-        "❌ 无法获取频道信息，请确保在正确的频道中使用此命令。",
-      );
-    }
-
-    // 改进频道类型检查
-    const isValidChannel =
-      channel.isTextBased() ||
-      (channel.isThread && channel.isThread()) ||
-      channel.type === 0 || // GUILD_TEXT
-      channel.type === 11; // GUILD_PUBLIC_THREAD
-
-    if (!isValidChannel) {
-      return await interaction.editReply(
-        "❌ 此命令只能在文字频道或线程中使用。",
-      );
-    }
-
-    // 解析时间参数
     const startTimeStr = interaction.options.getString("开始时间");
     const endTimeStr = interaction.options.getString("结束时间");
-    const model = interaction.options.getString("模型"); // 获取模型参数
+    const model = interaction.options.getString("模型");
     const apiBaseUrl = interaction.options.getString("url");
     const apiKey = interaction.options.getString("api");
     const extraPrompt = interaction.options.getString("额外提示词");
 
-    const startTime = parseTimeInput(startTimeStr);
-    const endTime = parseTimeInput(endTimeStr);
-
-    // 验证时间范围
-    validateTimeRange(startTime, endTime, config.MAX_TIME_RANGE_DAYS);
-
-    await interaction.editReply("⏳ 开始收集消息...");
-
-    // 收集消息
-    const messages = await collectMessages(
-      channel,
-      startTime,
-      endTime,
-      config.MAX_MESSAGES,
-    );
-
-    if (messages.length === 0) {
-      return await interaction.editReply(
-        "❌ 在指定时间范围内没有找到任何消息。",
-      );
-    }
-
-    await interaction.editReply(
-      `📊 收集到 ${messages.length} 条消息，正在生成AI总结...`,
-    );
-
-    // 准备频道信息
-    const channelInfo = {
-      id: channel.id,
-      name: channel.name || "未命名频道",
-      type: channel.type,
-      timeRange: {
-        start: startTime.toISOString(),
-        end: endTime.toISOString(),
-      },
-    };
-
-    // 生成AI总结
-    const aiSummary = await generateSummary(messages, channelInfo, model, {
+    await executeSummary(interaction, {
+      startTimeStr,
+      endTimeStr,
+      model,
       apiBaseUrl,
       apiKey,
       extraPrompt,
     });
-
-    await interaction.editReply("📝 正在生成文件和总结...");
-
-    // 生成并保存JSON（只包含消息数据）
-    const messagesData = generateMessagesJSON(channelInfo, messages);
-    const fileInfo = await saveToTempFile(messagesData, channelInfo.name);
-
-    // 创建附件
-    const attachment = new AttachmentBuilder(fileInfo.filePath, {
-      name: fileInfo.fileName,
-    });
-
-    // 清理过期文件
-    cleanupTempFiles(config.FILE_RETENTION_HOURS).catch(console.warn);
-
-    // 先私密回复完成信息和文件
-    const completionEmbed = {
-      color: 0x00ff00,
-      title: "✅ 频道内容总结完成",
-      fields: [
-        { name: "频道", value: channelInfo.name, inline: true },
-        { name: "消息数量", value: messages.length.toString(), inline: true },
-        {
-          name: "参与用户",
-          value: aiSummary.participant_stats.total_participants.toString(),
-          inline: true,
-        },
-        {
-          name: "时间范围",
-          value: `${startTimeStr} 至 ${endTimeStr}`,
-          inline: false,
-        },
-        {
-          name: "文件大小",
-          value: `${Math.round(fileInfo.size / 1024)} KB`,
-          inline: true,
-        },
-      ],
-      description: "📁 消息数据已导出到JSON文件\n🤖 AI总结将以公开消息发送",
-      timestamp: new Date().toISOString(),
-    };
-
-    await interaction.editReply({
-      content: "处理完成！AI总结即将以公开消息发送...",
-      embeds: [completionEmbed],
-      files: [attachment],
-    });
-
-    // 发送公开的AI总结消息
-    const plainTextSummary = generatePlainTextSummary(
-      aiSummary,
-      channelInfo,
-      messages.length,
-    );
-    const summaryParts = splitLongText(plainTextSummary);
-
-    // 发送总结的开头信息
-    await interaction.channel.send(
-      `📋 **频道内容总结** (由 ${interaction.user.displayName} 发起)\n` +
-        `⏰ 时间范围: ${startTimeStr} 至 ${endTimeStr}`,
-    );
-
-    // 分段发送总结内容
-    for (let i = 0; i < summaryParts.length; i++) {
-      const part = summaryParts[i];
-      const isLastPart = i === summaryParts.length - 1;
-
-      if (isLastPart && summaryParts.length > 1) {
-        // 最后一条消息，生成并附加txt文件
-        try {
-          const textFile = await createSummaryTextFile(
-            aiSummary,
-            channelInfo,
-            messages.length,
-          );
-          const textAttachment = new AttachmentBuilder(textFile.filePath, {
-            name: textFile.fileName,
-          });
-
-          await interaction.channel.send({
-            content: `${part}\n\n📄 **完整总结已保存为文件**`,
-            files: [textAttachment],
-          });
-        } catch (fileError) {
-          console.warn("创建文本文件失败:", fileError);
-          await interaction.channel.send(part);
-        }
-      } else {
-        await interaction.channel.send(part);
-      }
-
-      // 避免发送过快
-      if (i < summaryParts.length - 1) {
-        await new Promise((resolve) => setTimeout(resolve, 500));
-      }
-    }
   } catch (error) {
     console.error("频道总结命令执行失败:", error);
 
@@ -280,7 +326,6 @@ async function execute(interaction) {
         ? error.message
         : "执行总结时发生错误，请稍后重试。";
 
-    // 5. 改进错误处理
     try {
       if (interaction.deferred || interaction.replied) {
         await interaction.editReply(`❌ ${errorMessage}`);
@@ -299,4 +344,7 @@ async function execute(interaction) {
 module.exports = {
   data,
   execute,
+  executeSummary,
+  applyTimeDefaults,
+  formatDateTime,
 };

--- a/src/modules/channelSummary/commands/summaryPreset.js
+++ b/src/modules/channelSummary/commands/summaryPreset.js
@@ -1,0 +1,382 @@
+// src/modules/channelSummary/commands/summaryPreset.js
+
+const { SlashCommandBuilder, MessageFlags } = require("discord.js");
+const presetService = require("../services/presetService");
+const perm = require("../services/permissionService");
+const config = require("../config/presetConfig");
+const {
+  buildPresetEmbed,
+  buildPresetActionRow,
+  buildPanelEmbed,
+  buildPanelAddRoleSelect,
+  buildPanelRemoveRoleSelect,
+} = require("../components/presetComponents");
+
+const data = new SlashCommandBuilder()
+  .setName("总结预设")
+  .setDescription("管理频道总结的参数预设")
+  .addSubcommand((sub) =>
+    sub
+      .setName("保存")
+      .setDescription("保存一组总结参数为预设")
+      .addStringOption((o) =>
+        o.setName("名称").setDescription("预设名称（唯一标识）").setRequired(true),
+      )
+      .addStringOption((o) =>
+        o.setName("开始时间").setDescription("默认开始时间 (YYYY-MM-DD HH:mm)").setRequired(false),
+      )
+      .addStringOption((o) =>
+        o.setName("结束时间").setDescription("默认结束时间 (YYYY-MM-DD HH:mm)").setRequired(false),
+      )
+      .addStringOption((o) =>
+        o.setName("模型").setDescription("默认模型名称").setRequired(false),
+      )
+      .addStringOption((o) =>
+        o.setName("url").setDescription("OpenAI 兼容接口地址").setRequired(false),
+      )
+      .addStringOption((o) =>
+        o.setName("api").setDescription("API Key").setRequired(false),
+      )
+      .addStringOption((o) =>
+        o.setName("额外提示词").setDescription("默认附加提示词").setRequired(false),
+      )
+      .addBooleanOption((o) =>
+        o.setName("公开").setDescription("是否全服共享此预设（默认仅自己可见）").setRequired(false),
+      ),
+  )
+  .addSubcommand((sub) =>
+    sub.setName("列表").setDescription("列出你可用的所有预设"),
+  )
+  .addSubcommand((sub) =>
+    sub
+      .setName("删除")
+      .setDescription("删除一个预设")
+      .addStringOption((o) =>
+        o
+          .setName("名称")
+          .setDescription("要删除的预设名称")
+          .setRequired(true)
+          .setAutocomplete(true),
+      ),
+  )
+  .addSubcommand((sub) =>
+    sub
+      .setName("使用")
+      .setDescription("使用一个预设来执行频道总结")
+      .addStringOption((o) =>
+        o
+          .setName("名称")
+          .setDescription("要使用的预设名称")
+          .setRequired(true)
+          .setAutocomplete(true),
+      ),
+  )
+  .addSubcommand((sub) =>
+    sub.setName("管理").setDescription("管理全局授权身份组（仅限管理员）"),
+  );
+
+// ---- Autocomplete ----
+async function autocomplete(interaction) {
+  const subcommand = interaction.options.getSubcommand();
+  if (subcommand !== "删除" && subcommand !== "使用") return;
+
+  const focused = interaction.options.getFocused(true);
+  if (focused.name !== "名称") return;
+
+  const guildId = interaction.guild.id;
+  const userId = interaction.user.id;
+  const level = perm.getPermissionLevel(interaction.member, guildId);
+
+  let presets;
+  if (subcommand === "删除") {
+    if (level === "admin") {
+      // Admin: 看到所有预设（公用 + 私用）
+      presets = presetService.getAllPresets(guildId);
+    } else if (level === "authorized") {
+      // 授权用户：只看到自己创建的私用预设
+      const own = presetService.getUserPresets(guildId, userId, false);
+      presets = {};
+      for (const [name, p] of Object.entries(own)) {
+        if (p.ownerId === userId && !p.isPublic) {
+          presets[name] = p;
+        }
+      }
+    } else {
+      return interaction.respond([]);
+    }
+  } else {
+    // 使用：normal 无法使用；admin/authorized 显示自己的私用 + 全体公用
+    if (level === "normal") return interaction.respond([]);
+    presets = presetService.getUserPresets(guildId, userId, true);
+  }
+
+  const presetNames = Object.keys(presets || {});
+  const filtered = presetNames
+    .filter((n) => n.toLowerCase().includes(focused.value.toLowerCase()))
+    .slice(0, 25);
+
+  await interaction.respond(filtered.map((n) => ({ name: n, value: n })));
+}
+
+// ---- 保存 ----
+async function handleSave(interaction) {
+  const guildId = interaction.guild.id;
+  const userId = interaction.user.id;
+  const presetName = interaction.options.getString("名称");
+  const isPublic = interaction.options.getBoolean("公开") || false;
+
+  const level = perm.getPermissionLevel(interaction.member, guildId);
+  if (level === "normal") {
+    return interaction.reply({ content: perm.PERM_DENIED, flags: MessageFlags.Ephemeral });
+  }
+
+  if (isPublic) {
+    const publicCount = presetService.getPublicPresetCount(guildId);
+    if (publicCount >= config.MAX_PUBLIC_PRESETS_PER_GUILD) {
+      return interaction.reply({
+        content: `❌ 全服公用预设已达上限（${config.MAX_PUBLIC_PRESETS_PER_GUILD} 条）。`,
+        flags: MessageFlags.Ephemeral,
+      });
+    }
+  } else {
+    const privateCount = presetService.getPresetCount(guildId, userId);
+    if (privateCount >= config.MAX_PRIVATE_PRESETS_PER_USER) {
+      return interaction.reply({
+        content: `❌ 你的私有预设已达上限（${config.MAX_PRIVATE_PRESETS_PER_USER} 条）。`,
+        flags: MessageFlags.Ephemeral,
+      });
+    }
+  }
+
+  const values = {
+    startTime: interaction.options.getString("开始时间") || "",
+    endTime: interaction.options.getString("结束时间") || "",
+    model: interaction.options.getString("模型") || "",
+    apiBaseUrl: interaction.options.getString("url") || "",
+    apiKey: interaction.options.getString("api") || "",
+    extraPrompt: interaction.options.getString("额外提示词") || "",
+    isPublic,
+  };
+
+  const isNew = await presetService.savePreset(guildId, userId, presetName, values);
+
+  return interaction.reply({
+    content: isNew
+      ? `✅ 预设「${presetName}」已保存（${isPublic ? "🌍 公开" : "🔒 私有"}）。`
+      : `✅ 预设「${presetName}」已更新（${isPublic ? "🌍 公开" : "🔒 私有"}）。`,
+    flags: MessageFlags.Ephemeral,
+  });
+}
+
+// ---- 列表 ----
+async function handleList(interaction) {
+  const guildId = interaction.guild.id;
+  const userId = interaction.user.id;
+
+  const level = perm.getPermissionLevel(interaction.member, guildId);
+  if (level === "normal") {
+    return interaction.reply({ content: perm.PERM_DENIED, flags: MessageFlags.Ephemeral });
+  }
+
+  const isAuth = level === "admin" || level === "authorized";
+  const presets = presetService.getUserPresets(guildId, userId, isAuth);
+  const names = Object.keys(presets);
+
+  if (names.length === 0) {
+    return interaction.reply({
+      content: "📭 你还没有保存任何预设，且当前没有可用的公开预设。",
+      flags: MessageFlags.Ephemeral,
+    });
+  }
+
+  const lines = names.map((n) => {
+    const p = presets[n];
+    const isOwn = p.ownerId === userId;
+    const icon = p.isPublic ? "🌍" : "🔒";
+    const ownerHint = isOwn ? "" : ` (by <@${p.ownerId}>)`;
+    return `• ${icon} **${n}**${ownerHint}`;
+  });
+
+  const ownCount = names.filter((n) => presets[n].ownerId === userId).length;
+  const publicCount = names.length - ownCount;
+
+  const embed = {
+    color: 0x3498db,
+    title: "📋 可用频道总结预设",
+    description: lines.join("\n"),
+    footer: {
+      text: `私有 ${ownCount}/${config.MAX_PRIVATE_PRESETS_PER_USER} | 可用公开 ${publicCount} 个`,
+    },
+  };
+
+  return interaction.reply({ embeds: [embed], flags: MessageFlags.Ephemeral });
+}
+
+// ---- 删除 ----
+async function handleDelete(interaction) {
+  const guildId = interaction.guild.id;
+  const userId = interaction.user.id;
+  const presetName = interaction.options.getString("名称");
+
+  const level = perm.getPermissionLevel(interaction.member, guildId);
+  if (level === "normal") {
+    return interaction.reply({ content: perm.PERM_DENIED, flags: MessageFlags.Ephemeral });
+  }
+
+  let preset;
+
+  if (level === "admin") {
+    // Admin: 可以看到并删除所有预设
+    const allPresets = presetService.getAllPresets(guildId);
+    preset = allPresets[presetName] || null;
+  } else {
+    // 授权用户: 只能从自己的私用预设中查找
+    const ownPresets = presetService.getUserPresets(guildId, userId, false);
+    const candidate = ownPresets[presetName];
+    if (candidate && candidate.ownerId === userId && !candidate.isPublic) {
+      preset = candidate;
+    }
+  }
+
+  if (!preset) {
+    return interaction.reply({
+      content: `❌ 未找到预设「${presetName}」。`,
+      flags: MessageFlags.Ephemeral,
+    });
+  }
+
+  // 非 Admin 尝试删除公用预设 → 拒绝
+  if (preset.isPublic && level !== "admin") {
+    return interaction.reply({ content: perm.PERM_DENIED, flags: MessageFlags.Ephemeral });
+  }
+
+  let deleted;
+  if (level === "admin" && preset.ownerId !== userId) {
+    deleted = presetService.forceDeletePreset(guildId, presetName);
+  } else {
+    deleted = presetService.deletePreset(guildId, userId, presetName);
+  }
+
+  return interaction.reply({
+    content: deleted
+      ? `✅ 预设「${presetName}」已删除。`
+      : `❌ 删除失败。`,
+    flags: MessageFlags.Ephemeral,
+  });
+}
+
+// ---- 使用 ----
+async function handleUse(interaction) {
+  const guildId = interaction.guild.id;
+  const userId = interaction.user.id;
+  const presetName = interaction.options.getString("名称");
+
+  const level = perm.getPermissionLevel(interaction.member, guildId);
+  if (level === "normal") {
+    return interaction.reply({ content: perm.PERM_DENIED, flags: MessageFlags.Ephemeral });
+  }
+
+  const isAuth = level === "admin" || level === "authorized";
+  const preset = presetService.getPreset(guildId, userId, presetName, isAuth);
+  if (!preset) {
+    return interaction.reply({
+      content: `❌ 未找到预设「${presetName}」。`,
+      flags: MessageFlags.Ephemeral,
+    });
+  }
+
+  // 私有预设：仅主人可用
+  if (!preset.isPublic && preset.ownerId !== userId) {
+    return interaction.reply({ content: perm.PERM_DENIED, flags: MessageFlags.Ephemeral });
+  }
+
+  const flowId = presetService.generateFlowId();
+  presetService.createFlow(flowId, {
+    guildId,
+    channelId: interaction.channelId,
+    userId,
+    presetName,
+    startTime: preset.startTime,
+    endTime: preset.endTime,
+    model: preset.model,
+    apiBaseUrl: preset.apiBaseUrl,
+    apiKey: preset.apiKey,
+    extraPrompt: preset.extraPrompt,
+    isPublic: preset.isPublic || false,
+    ownerId: preset.ownerId,
+    createdAt: new Date().toISOString(),
+  });
+
+  const embed = buildPresetEmbed(
+    {
+      startTime: preset.startTime,
+      endTime: preset.endTime,
+      model: preset.model,
+      apiBaseUrl: preset.apiBaseUrl,
+      apiKey: preset.apiKey,
+      extraPrompt: preset.extraPrompt,
+    },
+    presetName,
+    {
+      viewerUserId: userId,
+      ownerId: preset.ownerId,
+      isPublic: preset.isPublic,
+    },
+  );
+  const row = buildPresetActionRow(flowId);
+
+  return interaction.reply({
+    embeds: [embed],
+    components: [row],
+    flags: MessageFlags.Ephemeral,
+  });
+}
+
+// ---- 管理面板 ----
+async function handleManage(interaction) {
+  const guildId = interaction.guild.id;
+
+  const level = perm.getPermissionLevel(interaction.member, guildId);
+  if (level !== "admin") {
+    return interaction.reply({ content: perm.PERM_DENIED, flags: MessageFlags.Ephemeral });
+  }
+
+  const authorizedRoles = presetService.getAllAuthorizedRoles();
+  const embed = buildPanelEmbed(authorizedRoles);
+
+  const components = [];
+  components.push(buildPanelAddRoleSelect());
+  const removeSelect = buildPanelRemoveRoleSelect(authorizedRoles);
+  if (removeSelect) components.push(removeSelect);
+
+  return interaction.reply({
+    embeds: [embed],
+    components,
+    flags: MessageFlags.Ephemeral,
+  });
+}
+
+// ---- 主入口 ----
+async function execute(interaction) {
+  const subcommand = interaction.options.getSubcommand();
+
+  switch (subcommand) {
+    case "保存":
+      return handleSave(interaction);
+    case "列表":
+      return handleList(interaction);
+    case "删除":
+      return handleDelete(interaction);
+    case "使用":
+      return handleUse(interaction);
+    case "管理":
+      return handleManage(interaction);
+    default:
+      return interaction.reply({
+        content: "❌ 未知子命令。",
+        flags: MessageFlags.Ephemeral,
+      });
+  }
+}
+
+module.exports = { data, execute, autocomplete };

--- a/src/modules/channelSummary/components/presetComponents.js
+++ b/src/modules/channelSummary/components/presetComponents.js
@@ -1,0 +1,188 @@
+// src/modules/channelSummary/components/presetComponents.js
+
+const { TextInputStyle } = require("discord.js");
+
+// ---- API Key 脱敏 ----
+
+function maskApiKey(key) {
+  if (!key) return "（未设置）";
+  if (key.length <= 8) return "********";
+  return key.substring(0, 3) + "***" + key.substring(key.length - 4);
+}
+
+function maskApiKeyFull() {
+  return "********";
+}
+
+// ---- Modal ----
+
+function createEditPresetModal(flowId, presetValues) {
+  const { ModalBuilder, TextInputBuilder, ActionRowBuilder } = require("discord.js");
+
+  const modal = new ModalBuilder()
+    .setCustomId(`preset_edit_modal_${flowId}`)
+    .setTitle("修改预设参数");
+
+  const startTimeInput = new TextInputBuilder()
+    .setCustomId("preset_startTime")
+    .setLabel("开始时间 (YYYY-MM-DD HH:mm)")
+    .setStyle(TextInputStyle.Short)
+    .setValue(presetValues.startTime || "")
+    .setRequired(true);
+
+  const endTimeInput = new TextInputBuilder()
+    .setCustomId("preset_endTime")
+    .setLabel("结束时间 (YYYY-MM-DD HH:mm)")
+    .setStyle(TextInputStyle.Short)
+    .setValue(presetValues.endTime || "")
+    .setRequired(true);
+
+  const modelInput = new TextInputBuilder()
+    .setCustomId("preset_model")
+    .setLabel("模型 (留空使用默认)")
+    .setStyle(TextInputStyle.Short)
+    .setValue(presetValues.model || "")
+    .setRequired(false);
+
+  const extraPromptInput = new TextInputBuilder()
+    .setCustomId("preset_extraPrompt")
+    .setLabel("额外提示词 (可选)")
+    .setStyle(TextInputStyle.Paragraph)
+    .setValue(presetValues.extraPrompt || "")
+    .setRequired(false);
+
+  modal.addComponents(
+    new ActionRowBuilder().addComponents(startTimeInput),
+    new ActionRowBuilder().addComponents(endTimeInput),
+    new ActionRowBuilder().addComponents(modelInput),
+    new ActionRowBuilder().addComponents(extraPromptInput),
+  );
+
+  return modal;
+}
+
+// ---- Embed ----
+
+function buildPresetEmbed(presetValues, presetName, options = {}) {
+  const { viewerUserId, ownerId, isPublic } = options;
+  const isOwner = !ownerId || viewerUserId === ownerId;
+
+  let apiKeyDisplay;
+  if (!presetValues.apiKey) {
+    apiKeyDisplay = "（未设置）";
+  } else if (!isOwner && isPublic) {
+    apiKeyDisplay = maskApiKeyFull();
+  } else {
+    apiKeyDisplay = maskApiKey(presetValues.apiKey);
+  }
+
+  const titleParts = [`📋 预设「${presetName}」参数确认`];
+  if (isPublic && !isOwner) {
+    titleParts.push(" 🌍（公开预设）");
+  }
+
+  const fields = [
+    { name: "开始时间", value: presetValues.startTime || "（未设置）", inline: true },
+    { name: "结束时间", value: presetValues.endTime || "（未设置）", inline: true },
+    { name: "模型", value: presetValues.model || "（使用默认模型）", inline: true },
+    { name: "API Base URL", value: presetValues.apiBaseUrl || "（使用默认地址）", inline: true },
+    { name: "API Key", value: apiKeyDisplay, inline: true },
+    { name: "额外提示词", value: presetValues.extraPrompt || "（无）", inline: false },
+  ];
+
+  if (isPublic && !isOwner && ownerId) {
+    fields.push({ name: "创建者", value: `<@${ownerId}>`, inline: true });
+  }
+
+  return {
+    color: isPublic ? 0x2ecc71 : 0x3498db,
+    title: titleParts.join(""),
+    fields,
+    footer: { text: "请确认参数后点击下方按钮操作" },
+    timestamp: new Date().toISOString(),
+  };
+}
+
+// ---- ActionRow ----
+
+function buildPresetActionRow(flowId) {
+  const { ButtonBuilder, ButtonStyle, ActionRowBuilder } = require("discord.js");
+
+  return new ActionRowBuilder().addComponents(
+    new ButtonBuilder()
+      .setCustomId(`preset_confirm_${flowId}`)
+      .setLabel("确认执行")
+      .setStyle(ButtonStyle.Success),
+    new ButtonBuilder()
+      .setCustomId(`preset_edit_${flowId}`)
+      .setLabel("修改参数")
+      .setStyle(ButtonStyle.Primary),
+    new ButtonBuilder()
+      .setCustomId(`preset_cancel_${flowId}`)
+      .setLabel("取消")
+      .setStyle(ButtonStyle.Secondary),
+  );
+}
+
+// ---- 管理面板组件 ----
+
+/**
+ * 构建管理面板 Embed — 展示当前已授权身份组列表
+ */
+function buildPanelEmbed(authorizedRoleIds) {
+  const lines =
+    authorizedRoleIds.length > 0
+      ? authorizedRoleIds.map((rid) => `• <@&${rid}>`).join("\n")
+      : "（暂无授权身份组）";
+
+  return {
+    color: 0x9b59b6,
+    title: "⚙️ 总结预设授权管理面板",
+    description: `**当前已授权的身份组 (全局)：**\n${lines}\n\n使用下方菜单**添加**或**移除**授权身份组。`,
+    footer: { text: "仅管理员可操作" },
+  };
+}
+
+/**
+ * 构建添加授权的 RoleSelectMenu
+ */
+function buildPanelAddRoleSelect() {
+  const { RoleSelectMenuBuilder, ActionRowBuilder } = require("discord.js");
+
+  return new ActionRowBuilder().addComponents(
+    new RoleSelectMenuBuilder()
+      .setCustomId("preset_panel_add_role")
+      .setPlaceholder("➕ 添加授权身份组..."),
+  );
+}
+
+/**
+ * 构建移除授权的 StringSelectMenu（枚举已授权 role）
+ */
+function buildPanelRemoveRoleSelect(authorizedRoleIds) {
+  const { StringSelectMenuBuilder, ActionRowBuilder } = require("discord.js");
+
+  if (!authorizedRoleIds || authorizedRoleIds.length === 0) return null;
+
+  const options = authorizedRoleIds.slice(0, 25).map((rid) => ({
+    label: `移除: ${rid}`,
+    value: rid,
+  }));
+
+  return new ActionRowBuilder().addComponents(
+    new StringSelectMenuBuilder()
+      .setCustomId("preset_panel_remove_role")
+      .setPlaceholder("➖ 移除授权身份组...")
+      .addOptions(options),
+  );
+}
+
+module.exports = {
+  createEditPresetModal,
+  buildPresetEmbed,
+  buildPresetActionRow,
+  maskApiKey,
+  buildPanelEmbed,
+  buildPanelAddRoleSelect,
+  buildPanelRemoveRoleSelect,
+};

--- a/src/modules/channelSummary/config/presetConfig.js
+++ b/src/modules/channelSummary/config/presetConfig.js
@@ -1,0 +1,16 @@
+// src/modules/channelSummary/config/presetConfig.js
+
+const path = require("path");
+
+const DATA_DIR = path.join(process.cwd(), "data");
+
+module.exports = {
+  /** SQLite 数据库文件路径 */
+  PRESET_DB_PATH: path.join(DATA_DIR, "channelSummaryPresets.sqlite"),
+
+  /** 每人私有预设数量上限 */
+  MAX_PRIVATE_PRESETS_PER_USER: 5,
+
+  /** 全服公用预设数量上限 */
+  MAX_PUBLIC_PRESETS_PER_GUILD: 5,
+};

--- a/src/modules/channelSummary/config/summaryConfig.js
+++ b/src/modules/channelSummary/config/summaryConfig.js
@@ -1,8 +1,11 @@
 // src/modules/channelSummary/config/summaryConfig.js
 
 module.exports = {
-    // 最大消息数量限制
-    MAX_MESSAGES: process.env.SUMMARY_MAX_MESSAGES || 1000,
+    // 最大消息数量限制 (单次总结拉取上限)
+    MAX_MESSAGES: 3000,
+
+    // 默认时间范围（天）：当用户未提供开始时间时的回看天数
+    DEFAULT_TIME_RANGE_DAYS: 30,
     
     // 最大时间范围（天）
     MAX_TIME_RANGE_DAYS: 30,

--- a/src/modules/channelSummary/services/permissionService.js
+++ b/src/modules/channelSummary/services/permissionService.js
@@ -1,0 +1,48 @@
+// src/modules/channelSummary/services/permissionService.js
+
+const presetService = require("./presetService");
+
+const PERM_DENIED = "❌ 权限不足：仅授权用户使用此功能。";
+
+function parseEnvList(raw) {
+  if (!raw || typeof raw !== "string") return [];
+  return raw
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+}
+
+/**
+ * 判断用户是否拥有管理员身份组（from .env SUMMARY_ADMIN_ROLE_IDS）
+ */
+function isAdmin(member) {
+  const adminRoleIds = parseEnvList(process.env.SUMMARY_ADMIN_ROLE_IDS);
+  if (adminRoleIds.length === 0) return false;
+  return adminRoleIds.some((rid) => member.roles.cache.has(rid));
+}
+
+/**
+ * 判断用户是否拥有全局授权身份组（查 summary_authorized_roles 表）
+ */
+function isAuthorized(member) {
+  const memberRoleIds = [...member.roles.cache.keys()];
+  return presetService.hasAnyAuthorizedRole(memberRoleIds);
+}
+
+/**
+ * 获取用户权限等级
+ * @returns {"admin" | "authorized" | "normal"}
+ */
+function getPermissionLevel(member, guildId) {
+  if (isAdmin(member)) return "admin";
+  if (isAuthorized(member)) return "authorized";
+  return "normal";
+}
+
+module.exports = {
+  PERM_DENIED,
+  parseEnvList,
+  isAdmin,
+  isAuthorized,
+  getPermissionLevel,
+};

--- a/src/modules/channelSummary/services/presetInteractionHandler.js
+++ b/src/modules/channelSummary/services/presetInteractionHandler.js
@@ -1,0 +1,386 @@
+// src/modules/channelSummary/services/presetInteractionHandler.js
+
+const { MessageFlags, AttachmentBuilder } = require("discord.js");
+const presetService = require("./presetService");
+const perm = require("./permissionService");
+const {
+  buildPresetEmbed,
+  buildPresetActionRow,
+  createEditPresetModal,
+  buildPanelEmbed,
+  buildPanelAddRoleSelect,
+  buildPanelRemoveRoleSelect,
+} = require("../components/presetComponents");
+const { parseTimeInput, validateTimeRange } = require("../utils/timeParser");
+const { collectMessages } = require("./messageCollector");
+const { generateSummary } = require("./aiSummaryService");
+const {
+  generateMessagesJSON,
+  saveToTempFile,
+  cleanupTempFiles,
+} = require("./jsonExporter");
+const {
+  generatePlainTextSummary,
+  splitLongText,
+  createSummaryTextFile,
+} = require("../utils/summaryFormatter");
+const summaryConfig = require("../config/summaryConfig");
+const { applyTimeDefaults } = require("../commands/summarizeChannel");
+
+// ---- 按钮处理 ----
+async function handlePresetButton(interaction) {
+  const customId = interaction.customId;
+
+  if (customId.startsWith("preset_confirm_")) {
+    return handleConfirm(interaction);
+  } else if (customId.startsWith("preset_edit_")) {
+    return handleEdit(interaction);
+  } else if (customId.startsWith("preset_cancel_")) {
+    return handleCancel(interaction);
+  }
+}
+
+async function handleConfirm(interaction) {
+  const flowId = interaction.customId.replace("preset_confirm_", "");
+  const flow = presetService.getFlow(flowId);
+
+  if (!flow) {
+    return interaction.reply({
+      content: "❌ 该预设会话已过期，请重新使用 `/总结预设 使用`。",
+      flags: MessageFlags.Ephemeral,
+    });
+  }
+
+  presetService.deleteFlow(flowId);
+  await interaction.deferUpdate();
+  await runPresetSummary(interaction, flow);
+}
+
+async function runPresetSummary(interaction, flow) {
+  try {
+    let channel = interaction.channel;
+    if (!channel) {
+      try {
+        channel = await interaction.guild.channels.fetch(interaction.channelId);
+      } catch {
+        await interaction.editReply({
+          content: "❌ 无法获取频道信息。",
+          embeds: [],
+          components: [],
+        });
+        return;
+      }
+    }
+
+    const { startTimeStr, endTimeStr, usedDefaultTime } = applyTimeDefaults(
+      flow.startTime,
+      flow.endTime,
+    );
+
+    const startTime = parseTimeInput(startTimeStr);
+    const endTime = parseTimeInput(endTimeStr);
+    validateTimeRange(startTime, endTime, summaryConfig.MAX_TIME_RANGE_DAYS);
+
+    let collectingMsg = "⏳ 开始收集消息...";
+    if (usedDefaultTime) {
+      collectingMsg += `\n> 📌 预设未设置完整时间参数，已自动拉取本频道近 ${summaryConfig.DEFAULT_TIME_RANGE_DAYS} 天内的消息（上限 ${summaryConfig.MAX_MESSAGES} 条）进行总结。`;
+    }
+    await interaction.editReply({
+      content: collectingMsg,
+      embeds: [],
+      components: [],
+    });
+
+    const messages = await collectMessages(
+      channel,
+      startTime,
+      endTime,
+      summaryConfig.MAX_MESSAGES,
+    );
+
+    if (messages.length === 0) {
+      return await interaction.editReply({
+        content: "❌ 在指定时间范围内没有找到任何消息。",
+        embeds: [],
+        components: [],
+      });
+    }
+
+    await interaction.editReply({
+      content: `📊 收集到 ${messages.length} 条消息，正在生成AI总结...`,
+      embeds: [],
+      components: [],
+    });
+
+    const channelInfo = {
+      id: channel.id,
+      name: channel.name || "未命名频道",
+      type: channel.type,
+      timeRange: {
+        start: startTime.toISOString(),
+        end: endTime.toISOString(),
+      },
+    };
+
+    const aiSummary = await generateSummary(
+      messages,
+      channelInfo,
+      flow.model || null,
+      {
+        apiBaseUrl: flow.apiBaseUrl || null,
+        apiKey: flow.apiKey || null,
+        extraPrompt: flow.extraPrompt || null,
+      },
+    );
+
+    await interaction.editReply({
+      content: "📝 正在生成文件和总结...",
+      embeds: [],
+      components: [],
+    });
+
+    const messagesData = generateMessagesJSON(channelInfo, messages);
+    const fileInfo = await saveToTempFile(messagesData, channelInfo.name);
+
+    const attachment = new AttachmentBuilder(fileInfo.filePath, {
+      name: fileInfo.fileName,
+    });
+
+    cleanupTempFiles(summaryConfig.FILE_RETENTION_HOURS).catch(console.warn);
+
+    const completionEmbed = {
+      color: 0x00ff00,
+      title: "✅ 频道内容总结完成",
+      fields: [
+        { name: "频道", value: channelInfo.name, inline: true },
+        { name: "消息数量", value: messages.length.toString(), inline: true },
+        {
+          name: "参与用户",
+          value: aiSummary.participant_stats.total_participants.toString(),
+          inline: true,
+        },
+        { name: "时间范围", value: `${startTimeStr} 至 ${endTimeStr}`, inline: false },
+        { name: "文件大小", value: `${Math.round(fileInfo.size / 1024)} KB`, inline: true },
+      ],
+      description: "📁 消息数据已导出到JSON文件\n🤖 AI总结将以公开消息发送",
+      timestamp: new Date().toISOString(),
+    };
+
+    await interaction.editReply({
+      content: "处理完成！AI总结即将以公开消息发送...",
+      embeds: [completionEmbed],
+      files: [attachment],
+    });
+
+    const plainTextSummary = generatePlainTextSummary(
+      aiSummary,
+      channelInfo,
+      messages.length,
+    );
+    const summaryParts = splitLongText(plainTextSummary);
+
+    await interaction.channel.send(
+      `📋 **频道内容总结** (由 ${interaction.user.displayName} 发起)\n` +
+        `⏰ 时间范围: ${startTimeStr} 至 ${endTimeStr}`,
+    );
+
+    for (let i = 0; i < summaryParts.length; i++) {
+      const part = summaryParts[i];
+      const isLastPart = i === summaryParts.length - 1;
+
+      if (isLastPart && summaryParts.length > 1) {
+        try {
+          const textFile = await createSummaryTextFile(
+            aiSummary,
+            channelInfo,
+            messages.length,
+          );
+          const textAttachment = new AttachmentBuilder(textFile.filePath, {
+            name: textFile.fileName,
+          });
+          await interaction.channel.send({
+            content: `${part}\n\n📄 **完整总结已保存为文件**`,
+            files: [textAttachment],
+          });
+        } catch (fileError) {
+          console.warn("创建文本文件失败:", fileError);
+          await interaction.channel.send(part);
+        }
+      } else {
+        await interaction.channel.send(part);
+      }
+
+      if (i < summaryParts.length - 1) {
+        await new Promise((resolve) => setTimeout(resolve, 500));
+      }
+    }
+  } catch (error) {
+    console.error("预设总结执行失败:", error);
+    const errorMessage =
+      error.message.includes("不支持的时间格式") ||
+      error.message.includes("无效的时间") ||
+      error.message.includes("时间范围")
+        ? error.message
+        : "执行总结时发生错误，请稍后重试。";
+    try {
+      await interaction.editReply({
+        content: `❌ ${errorMessage}`,
+        embeds: [],
+        components: [],
+      });
+    } catch {
+      try {
+        await interaction.followUp({
+          content: `❌ ${errorMessage}`,
+          flags: MessageFlags.Ephemeral,
+        });
+      } catch { /* 忽略 */ }
+    }
+  }
+}
+
+async function handleEdit(interaction) {
+  const flowId = interaction.customId.replace("preset_edit_", "");
+  const flow = presetService.getFlow(flowId);
+
+  if (!flow) {
+    return interaction.reply({
+      content: "❌ 该预设会话已过期。",
+      flags: MessageFlags.Ephemeral,
+    });
+  }
+
+  const modal = createEditPresetModal(flowId, {
+    startTime: flow.startTime,
+    endTime: flow.endTime,
+    model: flow.model,
+    extraPrompt: flow.extraPrompt,
+  });
+
+  await interaction.showModal(modal);
+}
+
+async function handleCancel(interaction) {
+  const flowId = interaction.customId.replace("preset_cancel_", "");
+  presetService.deleteFlow(flowId);
+
+  if (interaction.message) {
+    await interaction.update({
+      content: "❌ 已取消预设操作。",
+      embeds: [],
+      components: [],
+    });
+  } else {
+    await interaction.reply({
+      content: "❌ 已取消预设操作。",
+      flags: MessageFlags.Ephemeral,
+    });
+  }
+}
+
+// ---- Modal 处理 ----
+async function handlePresetModal(interaction) {
+  const flowId = interaction.customId.replace("preset_edit_modal_", "");
+  const flow = presetService.getFlow(flowId);
+
+  if (!flow) {
+    return interaction.reply({
+      content: "❌ 该预设会话已过期。",
+      flags: MessageFlags.Ephemeral,
+    });
+  }
+
+  const newStartTime = interaction.fields.getTextInputValue("preset_startTime");
+  const newEndTime = interaction.fields.getTextInputValue("preset_endTime");
+  const newModel = interaction.fields.getTextInputValue("preset_model");
+  const newExtraPrompt = interaction.fields.getTextInputValue("preset_extraPrompt");
+
+  presetService.updateFlowValues(flowId, {
+    startTime: newStartTime,
+    endTime: newEndTime,
+    model: newModel,
+    extraPrompt: newExtraPrompt,
+  });
+
+  const updatedFlow = presetService.getFlow(flowId);
+
+  const embed = buildPresetEmbed(
+    {
+      startTime: updatedFlow.startTime,
+      endTime: updatedFlow.endTime,
+      model: updatedFlow.model,
+      apiBaseUrl: updatedFlow.apiBaseUrl,
+      apiKey: updatedFlow.apiKey,
+      extraPrompt: updatedFlow.extraPrompt,
+    },
+    updatedFlow.presetName,
+    {
+      viewerUserId: interaction.user.id,
+      ownerId: updatedFlow.ownerId,
+      isPublic: updatedFlow.isPublic,
+    },
+  );
+  const row = buildPresetActionRow(flowId);
+
+  try {
+    await interaction.update({ embeds: [embed], components: [row] });
+  } catch {
+    await interaction.reply({
+      embeds: [embed],
+      components: [row],
+      flags: MessageFlags.Ephemeral,
+    });
+  }
+}
+
+// ---- 管理面板选择菜单处理 ----
+async function handlePresetSelect(interaction) {
+  const guildId = interaction.guild.id;
+  const customId = interaction.customId;
+
+  const level = perm.getPermissionLevel(interaction.member, guildId);
+  if (level !== "admin") {
+    return interaction.reply({ content: perm.PERM_DENIED, flags: MessageFlags.Ephemeral });
+  }
+
+  const authorizedRoles = presetService.getAllAuthorizedRoles();
+
+  if (customId === "preset_panel_add_role") {
+    // 添加授权身份组
+    const roleId = interaction.values[0];
+    presetService.addAuthorizedRole(roleId);
+
+    const updatedRoles = presetService.getAllAuthorizedRoles();
+    const embed = buildPanelEmbed(updatedRoles);
+    embed.description += `\n\n✅ 已添加授权身份组 <@&${roleId}>。`;
+
+    const components = [];
+    components.push(buildPanelAddRoleSelect());
+    const removeSelect = buildPanelRemoveRoleSelect(updatedRoles);
+    if (removeSelect) components.push(removeSelect);
+
+    await interaction.update({ embeds: [embed], components });
+
+  } else if (customId === "preset_panel_remove_role") {
+    // 移除授权身份组
+    const roleId = interaction.values[0];
+    presetService.removeAuthorizedRole(roleId);
+
+    const updatedRoles = presetService.getAllAuthorizedRoles();
+    const embed = buildPanelEmbed(updatedRoles);
+    embed.description += `\n\n✅ 已移除授权身份组 <@&${roleId}>。`;
+
+    const components = [];
+    components.push(buildPanelAddRoleSelect());
+    const removeSelect = buildPanelRemoveRoleSelect(updatedRoles);
+    if (removeSelect) components.push(removeSelect);
+
+    await interaction.update({ embeds: [embed], components });
+  }
+}
+
+module.exports = {
+  handlePresetButton,
+  handlePresetModal,
+  handlePresetSelect,
+};

--- a/src/modules/channelSummary/services/presetService.js
+++ b/src/modules/channelSummary/services/presetService.js
@@ -1,0 +1,315 @@
+// src/modules/channelSummary/services/presetService.js
+
+const fs = require("fs");
+const path = require("path");
+const crypto = require("crypto");
+const Database = require("better-sqlite3");
+const config = require("../config/presetConfig");
+
+// ---- SQLite 初始化 ----
+const dir = path.dirname(config.PRESET_DB_PATH);
+if (!fs.existsSync(dir)) {
+  fs.mkdirSync(dir, { recursive: true });
+}
+
+const db = new Database(config.PRESET_DB_PATH);
+db.pragma("journal_mode = WAL");
+db.pragma("foreign_keys = ON");
+
+db.exec(`
+  CREATE TABLE IF NOT EXISTS presets (
+    guild_id      TEXT NOT NULL,
+    user_id       TEXT NOT NULL,
+    name          TEXT NOT NULL,
+    start_time    TEXT DEFAULT '',
+    end_time      TEXT DEFAULT '',
+    model         TEXT DEFAULT '',
+    api_base_url  TEXT DEFAULT '',
+    api_key       TEXT DEFAULT '',
+    extra_prompt  TEXT DEFAULT '',
+    is_public     INTEGER DEFAULT 0,
+    created_at    TEXT NOT NULL,
+    updated_at    TEXT NOT NULL,
+    PRIMARY KEY (guild_id, user_id, name)
+  );
+`);
+
+// 全局授权身份组表（不绑 guild，全服生效）
+db.exec(`
+  CREATE TABLE IF NOT EXISTS summary_authorized_roles (
+    role_id TEXT PRIMARY KEY
+  );
+`);
+
+// 兼容旧列（废弃不使用）
+try { db.exec(`ALTER TABLE presets ADD COLUMN allowed_role_id TEXT DEFAULT ''`); } catch (_) {}
+
+// ---- 预编译语句 ----
+
+const stmtOwnPresets = db.prepare(
+  `SELECT * FROM presets WHERE guild_id = ? AND user_id = ? ORDER BY name ASC`,
+);
+const stmtPresetByName = db.prepare(
+  `SELECT * FROM presets WHERE guild_id = ? AND user_id = ? AND name = ?`,
+);
+const stmtPublicByName = db.prepare(
+  `SELECT * FROM presets WHERE guild_id = ? AND name = ? AND is_public = 1 AND user_id != ?`,
+);
+const stmtOwnCount = db.prepare(
+  `SELECT COUNT(*) AS cnt FROM presets WHERE guild_id = ? AND user_id = ?`,
+);
+const stmtPublicCount = db.prepare(
+  `SELECT COUNT(*) AS cnt FROM presets WHERE guild_id = ? AND is_public = 1`,
+);
+const stmtDeleteOwn = db.prepare(
+  `DELETE FROM presets WHERE guild_id = ? AND user_id = ? AND name = ?`,
+);
+const stmtDeleteAny = db.prepare(
+  `DELETE FROM presets WHERE guild_id = ? AND name = ?`,
+);
+const stmtAllPresets = db.prepare(
+  `SELECT * FROM presets WHERE guild_id = ? ORDER BY user_id, name ASC`,
+);
+const stmtExists = db.prepare(
+  `SELECT 1 FROM presets WHERE guild_id = ? AND user_id = ? AND name = ?`,
+);
+const stmtInsert = db.prepare(
+  `INSERT INTO presets
+     (guild_id, user_id, name, start_time, end_time, model, api_base_url,
+      api_key, extra_prompt, is_public, created_at, updated_at)
+   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+);
+
+// ---- 工具 ----
+
+function rowToPreset(row) {
+  if (!row) return null;
+  return {
+    name: row.name,
+    startTime: row.start_time || "",
+    endTime: row.end_time || "",
+    model: row.model || "",
+    apiBaseUrl: row.api_base_url || "",
+    apiKey: row.api_key || "",
+    extraPrompt: row.extra_prompt || "",
+    isPublic: row.is_public === 1,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+    ownerId: row.user_id,
+    guildId: row.guild_id,
+  };
+}
+
+// ---- 授权身份组表 ----
+
+function addAuthorizedRole(roleId) {
+  try {
+    db.prepare(`INSERT OR IGNORE INTO summary_authorized_roles (role_id) VALUES (?)`).run(roleId);
+    return true;
+  } catch { return false; }
+}
+
+function removeAuthorizedRole(roleId) {
+  const info = db.prepare(`DELETE FROM summary_authorized_roles WHERE role_id = ?`).run(roleId);
+  return info.changes > 0;
+}
+
+function getAllAuthorizedRoles() {
+  return db.prepare(`SELECT role_id FROM summary_authorized_roles`).all().map((r) => r.role_id);
+}
+
+/**
+ * 判断用户是否拥有任意授权身份组
+ */
+function hasAnyAuthorizedRole(memberRoleIds) {
+  if (!memberRoleIds.length) return false;
+  const placeholders = memberRoleIds.map(() => "?").join(",");
+  const row = db
+    .prepare(
+      `SELECT 1 FROM summary_authorized_roles WHERE role_id IN (${placeholders}) LIMIT 1`,
+    )
+    .get(...memberRoleIds);
+  return !!row;
+}
+
+// ---- 预设 CRUD ----
+
+/**
+ * 获取用户可见预设：自己的私用 +（若为授权用户）所有公用
+ */
+function getUserPresets(guildId, userId, isAuthorizedUser) {
+  let rows;
+  if (isAuthorizedUser) {
+    rows = db
+      .prepare(
+        `SELECT * FROM presets
+         WHERE guild_id = ? AND (user_id = ? OR is_public = 1)
+         ORDER BY is_public DESC, name ASC`,
+      )
+      .all(guildId, userId);
+  } else {
+    rows = stmtOwnPresets.all(guildId, userId);
+  }
+
+  const result = {};
+  for (const row of rows) {
+    result[row.name] = rowToPreset(row);
+  }
+  return result;
+}
+
+/**
+ * 获取单个预设。优先自己的；其次公用（授权用户才可见）。
+ */
+function getPreset(guildId, userId, presetName, isAuthorizedUser) {
+  let row = stmtPresetByName.get(guildId, userId, presetName);
+  if (row) return rowToPreset(row);
+
+  if (isAuthorizedUser) {
+    row = stmtPublicByName.get(guildId, presetName, userId);
+    if (row) {
+      const preset = rowToPreset(row);
+      preset.isForeign = true;
+      return preset;
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Admin 用：获取全服所有预设
+ */
+function getAllPresets(guildId) {
+  const rows = stmtAllPresets.all(guildId);
+  const result = {};
+  for (const row of rows) {
+    result[row.name] = rowToPreset(row);
+  }
+  return result;
+}
+
+/**
+ * 保存/更新预设
+ */
+function savePreset(guildId, userId, presetName, values) {
+  const existing = stmtExists.get(guildId, userId, presetName);
+  const isNew = !existing;
+  const now = new Date().toISOString();
+  const isPublic = values.isPublic ? 1 : 0;
+
+  if (isNew) {
+    stmtInsert.run(
+      guildId, userId, presetName,
+      values.startTime || "", values.endTime || "", values.model || "",
+      values.apiBaseUrl || "", values.apiKey || "", values.extraPrompt || "",
+      isPublic,
+      now, now,
+    );
+  } else {
+    db.prepare(
+      `UPDATE presets SET start_time=?, end_time=?, model=?, api_base_url=?, api_key=?,
+       extra_prompt=?, is_public=?, updated_at=?
+       WHERE guild_id=? AND user_id=? AND name=?`,
+    ).run(
+      values.startTime || "", values.endTime || "", values.model || "",
+      values.apiBaseUrl || "", values.apiKey || "", values.extraPrompt || "",
+      isPublic, now,
+      guildId, userId, presetName,
+    );
+  }
+
+  return isNew;
+}
+
+/**
+ * 删除自己的预设
+ */
+function deletePreset(guildId, userId, presetName) {
+  const info = stmtDeleteOwn.run(guildId, userId, presetName);
+  return info.changes > 0;
+}
+
+/**
+ * Admin 强制删除任意预设（含他人私用）
+ */
+function forceDeletePreset(guildId, presetName) {
+  const info = stmtDeleteAny.run(guildId, presetName);
+  return info.changes > 0;
+}
+
+/**
+ * 获取公用预设数量（全服）
+ */
+function getPublicPresetCount(guildId) {
+  const row = stmtPublicCount.get(guildId);
+  return row ? row.cnt : 0;
+}
+
+/**
+ * 获取用户的预设数量
+ */
+function getPresetCount(guildId, userId) {
+  const row = stmtOwnCount.get(guildId, userId);
+  return row ? row.cnt : 0;
+}
+
+// ---- Flow 会话管理（内存） ----
+
+const flowMap = new Map();
+
+function generateFlowId() {
+  return crypto.randomUUID();
+}
+
+function createFlow(flowId, data) {
+  flowMap.set(flowId, { ...data, flowId });
+}
+
+function getFlow(flowId) {
+  return flowMap.get(flowId) || null;
+}
+
+function updateFlowValues(flowId, updates) {
+  const flow = flowMap.get(flowId);
+  if (!flow) return null;
+  Object.assign(flow, updates);
+  return flow;
+}
+
+function deleteFlow(flowId) {
+  flowMap.delete(flowId);
+}
+
+setInterval(() => {
+  const cutoff = Date.now() - 30 * 60 * 1000;
+  for (const [id, flow] of flowMap) {
+    if (flow.createdAt && new Date(flow.createdAt).getTime() < cutoff) {
+      flowMap.delete(id);
+    }
+  }
+}, 5 * 60 * 1000);
+
+module.exports = {
+  // 授权身份组
+  addAuthorizedRole,
+  removeAuthorizedRole,
+  getAllAuthorizedRoles,
+  hasAnyAuthorizedRole,
+  // 预设 CRUD
+  getUserPresets,
+  getPreset,
+  getAllPresets,
+  savePreset,
+  deletePreset,
+  forceDeletePreset,
+  getPublicPresetCount,
+  getPresetCount,
+  // Flow
+  createFlow,
+  getFlow,
+  updateFlowValues,
+  deleteFlow,
+  generateFlowId,
+  flowMap,
+};


### PR DESCRIPTION
Summary
为频道总结模块新增完整的预设管理系统，支持参数预设的保存/列表/删除/使用，引入基于 .env 配置的三层权限架构（管理员 / 授权用户 / 普通用户），并优化了 /总结频道内容 命令的默认时间参数和消息拉取上限。

主要变更
预设管理系统（6 个新文件）
summaryPreset.js 提供 /总结预设 命令，含保存、列表、删除、使用、管理五个子命令。presetService.js 基于 SQLite 实现预设持久化（data/channelSummaryPresets.sqlite），支持公私有标记、Flow 会话管理、全局授权身份组表 summary_authorized_roles。presetComponents.js 包含 Modal、Embed、按钮 ActionRow、管理面板选择菜单等 UI 组件。presetInteractionHandler.js 处理全部按钮点击、Modal 提交、管理面板选择交互。permissionService.js 实现三层权限判定。presetConfig.js 配置预设数量上限与数据库路径。

三层权限架构
Admin 由 .env 中的 SUMMARY_ADMIN_ROLE_IDS 判定，拥有管理面板操作权、可强制删除任意预设、在删除列表中可查看全部预设。授权用户由 summary_authorized_roles 表判定，可保存/列表/使用/删除自己的预设，可使用全体公用预设。普通用户使用任何预设功能均返回统一权限不足提示。管理面板通过 RoleSelectMenu 添加授权、StringSelectMenu 移除授权。

核心逻辑重构
summarizeChannel.js 提取 executeSummary() 核心管线供 slash command 与 preset flow 共用。开始时间和结束时间改为可选参数，未填时默认拉取近 30 天消息（上限 3000 条），触发默认参数时在进度消息中追加说明。summaryConfig.js 的 MAX_MESSAGES 提升至 3000。

API Key 安全脱敏
长度不超过 8 字符全替换为星号；非所有者查看公用预设完全隐藏；所有者查看保留前三后四中间星号。

环境变量模板
.env.sample 新增 SUMMARY_ADMIN_ROLE_IDS 配置项，用于设置频道总结模块的管理员身份组 ID（逗号分隔）。

文件变更清单
新建：
src/modules/channelSummary/config/presetConfig.js
src/modules/channelSummary/services/presetService.js
src/modules/channelSummary/services/permissionService.js
src/modules/channelSummary/services/presetInteractionHandler.js
src/modules/channelSummary/components/presetComponents.js
src/modules/channelSummary/commands/summaryPreset.js

修改：
src/modules/channelSummary/commands/summarizeChannel.js
src/modules/channelSummary/config/summaryConfig.js
src/core/index.js
src/core/events/interactionCreate.js
.env.sample

Notes
所有权限拦截统一返回提示仅授权用户使用此功能。模块严格隔离，未修改 channelSummary 目录以外的任何业务模块代码。预设数据从 JSON 文件迁移至 SQLite（better-sqlite3），含旧表兼容逻辑。Discord Modal 限制 5 个 ActionRow，编辑预设时仅暴露 4 个业务字段（url 和 api 沿用预设原值不可见）。

Test plan
配置 SUMMARY_ADMIN_ROLE_IDS 后在管理面板中添加/移除授权身份组
授权用户能够保存、列表、使用公用预设和私用预设
授权用户无法在删除列表中看到他人私用预设或公用预设
Admin 能够强制删除任意预设
普通用户执行任何预设子命令均返回权限不足
/总结频道内容 不填时间参数时自动使用 30 天默认范围
消息拉取在 3000 条上限、到达起始时间、频道历史耗尽时正确停止
预设修改参数 Modal 仅显示 4 个字段，url 和 api 不可见
非所有者查看公用预设时 API Key 完全脱敏