### PR TITLE
feat: 新增 Discord 邀请暂停托管并统一总结预设权限

### DIFF
--- a/src/core/index.js
+++ b/src/core/index.js
@@ -160,6 +160,11 @@ const controlledInviteParamsCommand = require('../modules/controlledInvite/comma
 const controlledInviteToggleCommand = require('../modules/controlledInvite/commands/controlledInviteToggle');
 const viewMyControlledInviteStatusCommand = require('../modules/controlledInvite/commands/viewMyControlledInviteStatus');
 
+// Discord 安全措施（邀请暂停托管）
+const { startSafetySetupSystem } = require('../modules/safetySetup');
+const closeDoorCommand = require('../modules/safetySetup/commands/closeDoor');
+const openDoorCommand = require('../modules/safetySetup/commands/openDoor');
+
 const DISCORD_REST_TIMEOUT_MS = (() => {
     const n = Number(process.env.DISCORD_REST_TIMEOUT_MS);
     return Number.isFinite(n) && n > 0 ? n : 15000;
@@ -322,6 +327,10 @@ client.commands.set(controlledInviteParamsCommand.data.name, controlledInvitePar
 client.commands.set(controlledInviteToggleCommand.data.name, controlledInviteToggleCommand);
 client.commands.set(viewMyControlledInviteStatusCommand.data.name, viewMyControlledInviteStatusCommand);
 
+// Discord 安全措施
+client.commands.set(closeDoorCommand.data.name, closeDoorCommand);
+client.commands.set(openDoorCommand.data.name, openDoorCommand);
+
 client.once(Events.ClientReady, async (readyClient) => {
     try {
         // 启动时强制同步命令（clientReadyHandler 内部会执行 rest.put 刷新命令）
@@ -380,6 +389,9 @@ client.once(Events.ClientReady, async (readyClient) => {
 
     // 启动分服受控邀请系统
     await startControlledInviteSystem(readyClient);
+
+    // 启动 Discord 安全措施邀请暂停托管
+    await startSafetySetupSystem(readyClient);
 
     console.log('\n🤖 机器人已完全启动，所有系统正常运行！');
     console.log('🏆 赛事管理系统已加载');

--- a/src/modules/channelSummary/services/permissionService.js
+++ b/src/modules/channelSummary/services/permissionService.js
@@ -1,24 +1,17 @@
 // src/modules/channelSummary/services/permissionService.js
 
 const presetService = require("./presetService");
+const {
+  checkAdminPermission,
+} = require("../../../core/utils/permissionManager");
 
 const PERM_DENIED = "❌ 权限不足：仅授权用户使用此功能。";
 
-function parseEnvList(raw) {
-  if (!raw || typeof raw !== "string") return [];
-  return raw
-    .split(",")
-    .map((s) => s.trim())
-    .filter(Boolean);
-}
-
 /**
- * 判断用户是否拥有管理员身份组（from .env SUMMARY_ADMIN_ROLE_IDS）
+ * 使用全局统一规则判断用户是否拥有管理员权限
  */
 function isAdmin(member) {
-  const adminRoleIds = parseEnvList(process.env.SUMMARY_ADMIN_ROLE_IDS);
-  if (adminRoleIds.length === 0) return false;
-  return adminRoleIds.some((rid) => member.roles.cache.has(rid));
+  return checkAdminPermission(member);
 }
 
 /**
@@ -41,7 +34,6 @@ function getPermissionLevel(member, guildId) {
 
 module.exports = {
   PERM_DENIED,
-  parseEnvList,
   isAdmin,
   isAuthorized,
   getPermissionLevel,

--- a/src/modules/safetySetup/commands/closeDoor.js
+++ b/src/modules/safetySetup/commands/closeDoor.js
@@ -1,0 +1,95 @@
+const {
+    SlashCommandBuilder,
+    PermissionFlagsBits,
+    MessageFlags,
+} = require('discord.js');
+const {
+    checkAdminPermission,
+    getPermissionDeniedMessage,
+} = require('../../../core/utils/permissionManager');
+const { closeManagedGuild } = require('../services/safetyManager');
+const {
+    parseBeijingResumeTime,
+    formatBeijingDateTime,
+} = require('../utils/beijingTime');
+
+const data = new SlashCommandBuilder()
+    .setName('关门')
+    .setDescription('暂停服务器邀请并交由 Bot 自动续期托管')
+    .addStringOption((option) => option
+        .setName('恢复时间')
+        .setDescription('可选，北京时间 YYYY-MM-DD HH:mm；不填则仅 /开门 才恢复')
+        .setRequired(false));
+
+async function execute(interaction) {
+    if (!interaction.inGuild()) {
+        return interaction.reply({
+            content: '❌ 此命令只能在服务器中使用。',
+            flags: MessageFlags.Ephemeral,
+        });
+    }
+
+    if (!checkAdminPermission(interaction.member)) {
+        return interaction.reply({
+            content: getPermissionDeniedMessage(),
+            flags: MessageFlags.Ephemeral,
+        });
+    }
+
+    const botMember = interaction.guild.members.me;
+    if (!botMember?.permissions?.has(PermissionFlagsBits.ManageGuild)) {
+        return interaction.reply({
+            content: '❌ Bot 缺少“管理服务器（Manage Guild）”权限，无法暂停邀请。',
+            flags: MessageFlags.Ephemeral,
+        });
+    }
+
+    const resumeTimeInput = interaction.options.getString('恢复时间');
+    const nowMs = Date.now();
+    let resumeAt = null;
+
+    if (resumeTimeInput) {
+        try {
+            resumeAt = parseBeijingResumeTime(resumeTimeInput, nowMs);
+        } catch (error) {
+            return interaction.reply({
+                content: `❌ ${error.message}`,
+                flags: MessageFlags.Ephemeral,
+            });
+        }
+    }
+
+    await interaction.deferReply({ flags: MessageFlags.Ephemeral });
+
+    try {
+        const invitesDisabledUntil = await closeManagedGuild({
+            guild: interaction.guild,
+            guildId: interaction.guild.id,
+            enabledBy: interaction.user.id,
+            resumeAt: resumeAt?.toISOString() || null,
+            nowMs,
+        });
+
+        const discordUntilTimestamp = Math.floor(invitesDisabledUntil.getTime() / 1000);
+        const modeText = resumeAt
+            ? `预约在 **${formatBeijingDateTime(resumeAt)}（北京时间）** 自动恢复邀请。`
+            : '已启用无限期托管，直到执行 `/开门` 才恢复邀请。';
+
+        return interaction.editReply({
+            content: [
+                '🔒 **已关门：服务器邀请已暂停**',
+                '',
+                modeText,
+                `Discord 当前暂停截止：<t:${discordUntilTimestamp}:F>`,
+                'Bot 会在 Discord 的 24 小时限制到期前自动续期。',
+            ].join('\n'),
+        });
+    } catch (error) {
+        console.error(`[SafetySetup] /关门 执行失败 (guild=${interaction.guild.id}):`, error);
+        return interaction.editReply({
+            content: `❌ 暂停邀请失败，未启用自动托管：${error.message}`,
+        });
+    }
+}
+
+module.exports = { data, execute };

--- a/src/modules/safetySetup/commands/openDoor.js
+++ b/src/modules/safetySetup/commands/openDoor.js
@@ -1,0 +1,81 @@
+const {
+    SlashCommandBuilder,
+    PermissionFlagsBits,
+    MessageFlags,
+} = require('discord.js');
+const {
+    checkAdminPermission,
+    getPermissionDeniedMessage,
+} = require('../../../core/utils/permissionManager');
+const {
+    openManagedGuild,
+    disableManagedGuild,
+} = require('../services/safetyManager');
+
+const data = new SlashCommandBuilder()
+    .setName('开门')
+    .setDescription('停止邀请暂停托管并恢复服务器邀请');
+
+async function execute(interaction) {
+    if (!interaction.inGuild()) {
+        return interaction.reply({
+            content: '❌ 此命令只能在服务器中使用。',
+            flags: MessageFlags.Ephemeral,
+        });
+    }
+
+    if (!checkAdminPermission(interaction.member)) {
+        return interaction.reply({
+            content: getPermissionDeniedMessage(),
+            flags: MessageFlags.Ephemeral,
+        });
+    }
+
+    const guildId = interaction.guild.id;
+    const botMember = interaction.guild.members.me;
+    if (!botMember?.permissions?.has(PermissionFlagsBits.ManageGuild)) {
+        await interaction.deferReply({ flags: MessageFlags.Ephemeral });
+        try {
+            const result = await disableManagedGuild({ guildId });
+            const state = result.managed
+                ? '自动托管已停止；当前 Discord 暂停会在原截止时间自然结束，或可由后台手动恢复。'
+                : '当前服务器未由 Bot 托管，未修改 Discord 后台的安全措施。';
+            return interaction.editReply({
+                content: `⚠️ Bot 缺少“管理服务器（Manage Guild）”权限，无法立即恢复邀请。${state}`,
+            });
+        } catch (error) {
+            console.error(`[SafetySetup] /开门 停止托管失败 (guild=${guildId}):`, error);
+            return interaction.editReply({
+                content: `❌ Bot 缺少“管理服务器（Manage Guild）”权限，且无法确认自动托管是否已停止：${error.message}`,
+            });
+        }
+    }
+
+    await interaction.deferReply({ flags: MessageFlags.Ephemeral });
+
+    try {
+        const result = await openManagedGuild({
+            guild: interaction.guild,
+            guildId,
+        });
+        if (!result.managed) {
+            return interaction.editReply({
+                content: 'ℹ️ 当前服务器未由 Bot 托管，未修改 Discord 后台的安全措施。',
+            });
+        }
+        return interaction.editReply({
+            content: '🔓 **已开门：自动托管已停止，服务器邀请已恢复。**',
+        });
+    } catch (error) {
+        console.error(`[SafetySetup] /开门 执行失败 (guild=${guildId}):`, error);
+        return interaction.editReply({
+            content: [
+                '⚠️ 自动托管已停止，但 Discord 恢复邀请失败。',
+                'Bot 不会再次续期；当前暂停将在 Discord 原截止时间自然结束。',
+                `错误：${error.message}`,
+            ].join('\n'),
+        });
+    }
+}
+
+module.exports = { data, execute };

--- a/src/modules/safetySetup/index.js
+++ b/src/modules/safetySetup/index.js
@@ -1,0 +1,10 @@
+const safetyDatabase = require('./utils/safetyDatabase');
+const { startSafetyScheduler } = require('./services/safetyScheduler');
+
+async function startSafetySetupSystem(client) {
+    safetyDatabase.initializeSafetyDatabase();
+    startSafetyScheduler(client, safetyDatabase);
+    console.log('[SafetySetup] ✅ 邀请暂停托管系统已启动');
+}
+
+module.exports = { startSafetySetupSystem };

--- a/src/modules/safetySetup/services/guildOperationLock.js
+++ b/src/modules/safetySetup/services/guildOperationLock.js
@@ -1,0 +1,21 @@
+const guildOperationTails = new Map();
+
+async function withGuildOperationLock(guildId, operation) {
+    const previous = guildOperationTails.get(guildId) || Promise.resolve();
+    let release;
+    const gate = new Promise((resolve) => { release = resolve; });
+    const tail = previous.then(() => gate, () => gate);
+    guildOperationTails.set(guildId, tail);
+
+    await previous.catch(() => {});
+    try {
+        return await operation();
+    } finally {
+        release();
+        if (guildOperationTails.get(guildId) === tail) {
+            guildOperationTails.delete(guildId);
+        }
+    }
+}
+
+module.exports = { withGuildOperationLock };

--- a/src/modules/safetySetup/services/incidentService.js
+++ b/src/modules/safetySetup/services/incidentService.js
@@ -1,0 +1,43 @@
+const MAX_INCIDENT_PAUSE_MS = 24 * 60 * 60 * 1000;
+const RENEW_THRESHOLD_MS = 60 * 60 * 1000;
+
+function parseResumeAt(resumeAt) {
+    if (!resumeAt) return null;
+    const timestamp = resumeAt instanceof Date ? resumeAt.getTime() : Date.parse(resumeAt);
+    if (!Number.isFinite(timestamp)) {
+        throw new Error('无效的预约恢复时间');
+    }
+    return timestamp;
+}
+
+function calculatePauseUntil(nowMs = Date.now(), resumeAt = null) {
+    const maximumUntilMs = nowMs + MAX_INCIDENT_PAUSE_MS;
+    const resumeAtMs = parseResumeAt(resumeAt);
+    const untilMs = resumeAtMs === null
+        ? maximumUntilMs
+        : Math.min(maximumUntilMs, resumeAtMs);
+
+    if (!Number.isFinite(untilMs) || untilMs <= nowMs) {
+        throw new Error('预约恢复时间必须晚于当前时间');
+    }
+
+    return new Date(untilMs);
+}
+
+async function pauseInvites(guild, { nowMs = Date.now(), resumeAt = null } = {}) {
+    const invitesDisabledUntil = calculatePauseUntil(nowMs, resumeAt);
+    await guild.setIncidentActions({ invitesDisabledUntil });
+    return invitesDisabledUntil;
+}
+
+async function resumeInvites(guild) {
+    await guild.setIncidentActions({ invitesDisabledUntil: null });
+}
+
+module.exports = {
+    MAX_INCIDENT_PAUSE_MS,
+    RENEW_THRESHOLD_MS,
+    calculatePauseUntil,
+    pauseInvites,
+    resumeInvites,
+};

--- a/src/modules/safetySetup/services/safetyManager.js
+++ b/src/modules/safetySetup/services/safetyManager.js
@@ -1,0 +1,89 @@
+const { pauseInvites, resumeInvites } = require('./incidentService');
+const { withGuildOperationLock } = require('./guildOperationLock');
+
+function resolveStore(store) {
+    return store || require('../utils/safetyDatabase');
+}
+
+async function closeManagedGuild({
+    guild,
+    guildId,
+    enabledBy,
+    resumeAt = null,
+    nowMs = Date.now(),
+    now = () => Date.now(),
+    store = null,
+}) {
+    const operationStartedAtMs = now();
+    return withGuildOperationLock(guildId, async () => {
+        const persistence = resolveStore(store);
+        const operationGuild = typeof guild.fetch === 'function'
+            ? await guild.fetch()
+            : guild;
+        const previousPauseValue = operationGuild.incidentsData?.invitesDisabledUntil;
+        const previousPauseMs = previousPauseValue instanceof Date
+            ? previousPauseValue.getTime()
+            : Date.parse(previousPauseValue);
+        const invitesDisabledUntil = await pauseInvites(operationGuild, { nowMs, resumeAt });
+
+        try {
+            persistence.upsertManagedGuild({
+                guildId,
+                resumeAt: resumeAt || null,
+                enabledBy,
+                nowIso: new Date(nowMs).toISOString(),
+            });
+        } catch (persistenceError) {
+            try {
+                const elapsedMs = Math.max(0, now() - operationStartedAtMs);
+                const rollbackNowMs = nowMs + elapsedMs;
+                if (Number.isFinite(previousPauseMs) && previousPauseMs > rollbackNowMs) {
+                    await operationGuild.setIncidentActions({
+                        invitesDisabledUntil: new Date(previousPauseMs),
+                    });
+                } else {
+                    await resumeInvites(operationGuild);
+                }
+            } catch (rollbackError) {
+                throw new Error(
+                    `保存托管状态失败，且无法恢复之前的邀请状态：${persistenceError.message}；` +
+                    `恢复失败：${rollbackError.message}`,
+                    { cause: persistenceError },
+                );
+            }
+            throw persistenceError;
+        }
+
+        return invitesDisabledUntil;
+    });
+}
+
+async function openManagedGuild({ guild, guildId, store = null }) {
+    return withGuildOperationLock(guildId, async () => {
+        const persistence = resolveStore(store);
+        const record = persistence.getManagedGuild(guildId);
+        if (!record) return { managed: false };
+
+        const removed = persistence.removeManagedGuildIfRevision(guildId, record.revision);
+        if (!removed) return { managed: false };
+
+        await resumeInvites(guild);
+        return { managed: true };
+    });
+}
+
+async function disableManagedGuild({ guildId, store = null }) {
+    return withGuildOperationLock(guildId, async () => {
+        const persistence = resolveStore(store);
+        const record = persistence.getManagedGuild(guildId);
+        if (!record) return { managed: false };
+        const removed = persistence.removeManagedGuildIfRevision(guildId, record.revision);
+        return { managed: removed };
+    });
+}
+
+module.exports = {
+    closeManagedGuild,
+    openManagedGuild,
+    disableManagedGuild,
+};

--- a/src/modules/safetySetup/services/safetyScheduler.js
+++ b/src/modules/safetySetup/services/safetyScheduler.js
@@ -1,0 +1,182 @@
+const {
+    MAX_INCIDENT_PAUSE_MS,
+    RENEW_THRESHOLD_MS,
+    calculatePauseUntil,
+    pauseInvites,
+    resumeInvites,
+} = require('./incidentService');
+const { withGuildOperationLock } = require('./guildOperationLock');
+
+const RENEW_INTERVAL_MS = 30 * 60 * 1000;
+const DUE_INTERVAL_MS = 60 * 1000;
+const ALIGNMENT_TOLERANCE_MS = 1000;
+
+async function fetchFreshGuild(client, guildId) {
+    const guild = await client.guilds.fetch(guildId);
+    if (!guild) throw new Error('Bot 不在该服务器中或无法访问服务器');
+    return guild;
+}
+
+function getInvitePauseUntilMs(guild) {
+    const value = guild.incidentsData?.invitesDisabledUntil;
+    if (!value) return null;
+    const timestamp = value instanceof Date ? value.getTime() : Date.parse(value);
+    return Number.isFinite(timestamp) ? timestamp : null;
+}
+
+function createSafetyScheduler({
+    client,
+    store,
+    now = () => Date.now(),
+    logger = console,
+    setIntervalFn = setInterval,
+    clearIntervalFn = clearInterval,
+}) {
+    let renewalRunning = false;
+    let dueRunning = false;
+    let renewalTimer = null;
+    let dueTimer = null;
+
+    async function runRenewalSweep() {
+        if (renewalRunning) return false;
+        renewalRunning = true;
+
+        try {
+            const nowMs = now();
+            const records = store.listManagedGuilds();
+
+            for (const record of records) {
+                try {
+                    await withGuildOperationLock(record.guild_id, async () => {
+                        const currentRecord = store.getManagedGuild(record.guild_id);
+                        if (!currentRecord) return;
+
+                        const resumeAtMs = currentRecord.resume_at
+                            ? Date.parse(currentRecord.resume_at)
+                            : null;
+                        if (resumeAtMs !== null &&
+                            (!Number.isFinite(resumeAtMs) || resumeAtMs <= nowMs)) {
+                            return;
+                        }
+
+                        const guild = await fetchFreshGuild(client, currentRecord.guild_id);
+                        const currentUntilMs = getInvitePauseUntilMs(guild);
+                        const targetUntil = calculatePauseUntil(nowMs, currentRecord.resume_at);
+                        const targetUntilMs = targetUntil.getTime();
+                        const scheduledInFinalWindow = resumeAtMs !== null &&
+                            resumeAtMs <= nowMs + MAX_INCIDENT_PAUSE_MS;
+
+                        let needsUpdate;
+                        if (scheduledInFinalWindow) {
+                            needsUpdate = currentUntilMs === null ||
+                                Math.abs(currentUntilMs - targetUntilMs) > ALIGNMENT_TOLERANCE_MS;
+                        } else {
+                            needsUpdate = currentUntilMs === null ||
+                                currentUntilMs <= nowMs ||
+                                currentUntilMs - nowMs <= RENEW_THRESHOLD_MS;
+                        }
+
+                        if (!needsUpdate) return;
+                        await pauseInvites(guild, { nowMs, resumeAt: currentRecord.resume_at });
+                        logger.info?.(
+                            `[SafetySetup] 已续期服务器 ${currentRecord.guild_id} 的邀请暂停至 ${targetUntil.toISOString()}`,
+                        );
+                    });
+                } catch (error) {
+                    logger.error?.(`[SafetySetup] 续期服务器 ${record.guild_id} 失败:`, error);
+                }
+            }
+            return true;
+        } catch (error) {
+            logger.error?.('[SafetySetup] 读取托管服务器失败:', error);
+            return false;
+        } finally {
+            renewalRunning = false;
+        }
+    }
+
+    async function runDueSweep() {
+        if (dueRunning) return false;
+        dueRunning = true;
+
+        try {
+            const nowMs = now();
+            const records = store.listDueManagedGuilds(new Date(nowMs).toISOString());
+
+            for (const record of records) {
+                try {
+                    await withGuildOperationLock(record.guild_id, async () => {
+                        const currentRecord = store.getManagedGuild(record.guild_id);
+                        if (!currentRecord?.resume_at) return;
+                        const resumeAtMs = Date.parse(currentRecord.resume_at);
+                        if (!Number.isFinite(resumeAtMs) || resumeAtMs > nowMs) return;
+
+                        const guild = await fetchFreshGuild(client, currentRecord.guild_id);
+                        const currentUntilMs = getInvitePauseUntilMs(guild);
+                        if (currentUntilMs !== null && currentUntilMs > nowMs) {
+                            await resumeInvites(guild);
+                        }
+
+                        const removed = store.removeManagedGuildIfRevision(
+                            currentRecord.guild_id,
+                            currentRecord.revision,
+                        );
+                        if (removed) {
+                            logger.info?.(`[SafetySetup] 服务器 ${currentRecord.guild_id} 已按预约恢复邀请`);
+                        }
+                    });
+                } catch (error) {
+                    logger.error?.(
+                        `[SafetySetup] 恢复服务器 ${record.guild_id} 的邀请失败，将在下一轮重试:`,
+                        error,
+                    );
+                }
+            }
+            return true;
+        } catch (error) {
+            logger.error?.('[SafetySetup] 读取到期预约失败:', error);
+            return false;
+        } finally {
+            dueRunning = false;
+        }
+    }
+
+    function start() {
+        stop();
+        void runDueSweep();
+        void runRenewalSweep();
+        dueTimer = setIntervalFn(() => void runDueSweep(), DUE_INTERVAL_MS);
+        renewalTimer = setIntervalFn(() => void runRenewalSweep(), RENEW_INTERVAL_MS);
+    }
+
+    function stop() {
+        if (dueTimer) clearIntervalFn(dueTimer);
+        if (renewalTimer) clearIntervalFn(renewalTimer);
+        dueTimer = null;
+        renewalTimer = null;
+    }
+
+    return { start, stop, runRenewalSweep, runDueSweep };
+}
+
+let activeScheduler = null;
+
+function startSafetyScheduler(client, store, options = {}) {
+    if (activeScheduler) return activeScheduler;
+    activeScheduler = createSafetyScheduler({ client, store, ...options });
+    activeScheduler.start();
+    return activeScheduler;
+}
+
+function stopSafetyScheduler() {
+    if (activeScheduler) activeScheduler.stop();
+    activeScheduler = null;
+}
+
+module.exports = {
+    RENEW_INTERVAL_MS,
+    DUE_INTERVAL_MS,
+    createSafetyScheduler,
+    startSafetyScheduler,
+    stopSafetyScheduler,
+};

--- a/src/modules/safetySetup/utils/beijingTime.js
+++ b/src/modules/safetySetup/utils/beijingTime.js
@@ -1,0 +1,64 @@
+const BEIJING_OFFSET_MS = 8 * 60 * 60 * 1000;
+const MIN_RESUME_LEAD_MS = 60 * 60 * 1000;
+
+function parseBeijingResumeTime(input, nowMs = Date.now()) {
+    const value = String(input || '').trim();
+    const match = /^(\d{4})-(\d{2})-(\d{2}) (\d{2}):(\d{2})$/.exec(value);
+    if (!match) {
+        throw new Error('恢复时间格式错误，请使用 YYYY-MM-DD HH:mm（北京时间）');
+    }
+
+    const [, yearText, monthText, dayText, hourText, minuteText] = match;
+    const year = Number(yearText);
+    const month = Number(monthText);
+    const day = Number(dayText);
+    const hour = Number(hourText);
+    const minute = Number(minuteText);
+
+    if (
+        month < 1 || month > 12 ||
+        day < 1 || day > 31 ||
+        hour < 0 || hour > 23 ||
+        minute < 0 || minute > 59
+    ) {
+        throw new Error('无效的恢复时间，请检查年月日和时分');
+    }
+
+    const beijingWallClockAsUtc = Date.UTC(year, month - 1, day, hour, minute, 0, 0);
+    const parsedMs = beijingWallClockAsUtc - BEIJING_OFFSET_MS;
+    const roundTrip = new Date(parsedMs + BEIJING_OFFSET_MS);
+
+    if (
+        !Number.isFinite(parsedMs) ||
+        roundTrip.getUTCFullYear() !== year ||
+        roundTrip.getUTCMonth() !== month - 1 ||
+        roundTrip.getUTCDate() !== day ||
+        roundTrip.getUTCHours() !== hour ||
+        roundTrip.getUTCMinutes() !== minute
+    ) {
+        throw new Error('无效的恢复时间，请检查年月日和时分');
+    }
+
+    if (parsedMs - nowMs < MIN_RESUME_LEAD_MS) {
+        throw new Error('预约恢复时间必须至少提前 1 小时');
+    }
+
+    return new Date(parsedMs);
+}
+
+function formatBeijingDateTime(date) {
+    const shifted = new Date(date.getTime() + BEIJING_OFFSET_MS);
+    const year = shifted.getUTCFullYear();
+    const month = String(shifted.getUTCMonth() + 1).padStart(2, '0');
+    const day = String(shifted.getUTCDate()).padStart(2, '0');
+    const hour = String(shifted.getUTCHours()).padStart(2, '0');
+    const minute = String(shifted.getUTCMinutes()).padStart(2, '0');
+    return `${year}-${month}-${day} ${hour}:${minute}`;
+}
+
+module.exports = {
+    BEIJING_OFFSET_MS,
+    MIN_RESUME_LEAD_MS,
+    parseBeijingResumeTime,
+    formatBeijingDateTime,
+};

--- a/src/modules/safetySetup/utils/safetyDatabase.js
+++ b/src/modules/safetySetup/utils/safetyDatabase.js
@@ -1,0 +1,135 @@
+const fs = require('fs');
+const path = require('path');
+
+const DATA_DIR = path.join(__dirname, '../../../../data');
+const DATABASE_FILE = process.env.SAFETY_SETUP_DATABASE_FILE ||
+    path.join(DATA_DIR, 'safetySetup.sqlite');
+
+let database = null;
+let statements = null;
+
+function initializeSafetyDatabase() {
+    if (database) return database;
+
+    fs.mkdirSync(DATA_DIR, { recursive: true });
+    const Database = require('better-sqlite3');
+    database = new Database(DATABASE_FILE);
+    database.pragma('journal_mode = WAL');
+    database.pragma('synchronous = NORMAL');
+    database.pragma('busy_timeout = 5000');
+    database.exec(`
+        CREATE TABLE IF NOT EXISTS safety_invite_management (
+            guild_id TEXT PRIMARY KEY,
+            resume_at TEXT,
+            enabled_by TEXT NOT NULL,
+            created_at TEXT NOT NULL,
+            updated_at TEXT NOT NULL,
+            revision INTEGER NOT NULL DEFAULT 1
+        )
+    `);
+
+    const columns = database.pragma('table_info(safety_invite_management)');
+    if (!columns.some((column) => column.name === 'revision')) {
+        database.exec(`
+            ALTER TABLE safety_invite_management
+            ADD COLUMN revision INTEGER NOT NULL DEFAULT 1
+        `);
+    }
+
+    statements = {
+        upsert: database.prepare(`
+            INSERT INTO safety_invite_management (
+                guild_id, resume_at, enabled_by, created_at, updated_at, revision
+            ) VALUES (
+                @guild_id, @resume_at, @enabled_by, @created_at, @updated_at, 1
+            )
+            ON CONFLICT(guild_id) DO UPDATE SET
+                resume_at = excluded.resume_at,
+                enabled_by = excluded.enabled_by,
+                updated_at = excluded.updated_at,
+                revision = safety_invite_management.revision + 1
+        `),
+        remove: database.prepare('DELETE FROM safety_invite_management WHERE guild_id = ?'),
+        removeIfRevision: database.prepare(`
+            DELETE FROM safety_invite_management
+            WHERE guild_id = ? AND revision = ?
+        `),
+        get: database.prepare(`
+            SELECT guild_id, resume_at, enabled_by, created_at, updated_at, revision
+            FROM safety_invite_management
+            WHERE guild_id = ?
+        `),
+        listAll: database.prepare(`
+            SELECT guild_id, resume_at, enabled_by, created_at, updated_at, revision
+            FROM safety_invite_management
+            ORDER BY guild_id
+        `),
+        listDue: database.prepare(`
+            SELECT guild_id, resume_at, enabled_by, created_at, updated_at, revision
+            FROM safety_invite_management
+            WHERE resume_at IS NOT NULL AND resume_at <= ?
+            ORDER BY resume_at
+        `),
+    };
+
+    return database;
+}
+
+function ensureInitialized() {
+    if (!database) initializeSafetyDatabase();
+}
+
+function upsertManagedGuild({ guildId, resumeAt, enabledBy, nowIso = new Date().toISOString() }) {
+    ensureInitialized();
+    statements.upsert.run({
+        guild_id: guildId,
+        resume_at: resumeAt,
+        enabled_by: enabledBy,
+        created_at: nowIso,
+        updated_at: nowIso,
+    });
+    return statements.get.get(guildId);
+}
+
+function getManagedGuild(guildId) {
+    ensureInitialized();
+    return statements.get.get(guildId) || null;
+}
+
+function removeManagedGuild(guildId) {
+    ensureInitialized();
+    return statements.remove.run(guildId).changes > 0;
+}
+
+function removeManagedGuildIfRevision(guildId, revision) {
+    ensureInitialized();
+    return statements.removeIfRevision.run(guildId, revision).changes > 0;
+}
+
+function listManagedGuilds() {
+    ensureInitialized();
+    return statements.listAll.all();
+}
+
+function listDueManagedGuilds(nowIso = new Date().toISOString()) {
+    ensureInitialized();
+    return statements.listDue.all(nowIso);
+}
+
+function closeSafetyDatabase() {
+    if (database) database.close();
+    database = null;
+    statements = null;
+}
+
+module.exports = {
+    DATABASE_FILE,
+    initializeSafetyDatabase,
+    upsertManagedGuild,
+    getManagedGuild,
+    removeManagedGuild,
+    removeManagedGuildIfRevision,
+    listManagedGuilds,
+    listDueManagedGuilds,
+    closeSafetyDatabase,
+};


### PR DESCRIPTION
## 概要

新增独立的 Discord 安全措施邀请暂停托管模块：

- `/关门 [恢复时间]`：立即暂停邀请，可按北京时间 `YYYY-MM-DD HH:mm` 预约恢复；不填写时由 BOT 无限期托管。
- `/开门`：先停止托管，再立即恢复邀请。
- Discord 单次暂停最长 24 小时，BOT 每 30 分钟检查并在剩余不超过 1 小时时续期；预约到点每分钟重试恢复。
- 状态持久化到忽略目录中的 `data/safetySetup.sqlite`，支持启动恢复、并发锁、版本校验和单服故障隔离。

同时修正频道总结预设权限：管理员判定不再读取 `SUMMARY_ADMIN_ROLE_IDS`，统一委托现有 `checkAdminPermission`。

## 权限和影响范围

- `/关门`、`/开门` 统一调用项目现有 `checkAdminPermission`，不新增或修改共享管理员身份组配置。
- BOT 必须拥有 Manage Guild。
- 只发送 `invitesDisabledUntil`，不会读取或修改 `dmsDisabledUntil`。
- 未修改受控邀请模块或其他邀请创建逻辑；关门期间其他模块创建邀请被 Discord 拒绝属于预期行为。

## 可靠性处理

- Discord 暂停成功但 SQLite 写入失败时，恢复修改前的邀请暂停状态；若原截止时间在回滚前已过期，则恢复邀请。
- 持久化失败和回滚失败会同时报告，避免误报“未启用托管”。
- 重复启动安全调度器会复用现有实例，避免双重定时器和重叠扫描。
- 每个服务器使用独立操作锁和记录 revision，防止过期扫描覆盖新的 `/关门` 或 `/开门` 操作。
