### PR TITLE
feat(mystery): add multiplayer games and management tools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,9 @@ backupdata/
 backupdata/
 .limcode/
 .claude/
+data/mystery/bombCooldowns.json
+data/mystery/bombCooldowns.corrupt-*.json
+data/mystery/bombCooldowns.*.tmp
+data/mystery/namePool.json
+data/mystery/namePool.json.tmp
+data/mystery/namePool.corrupt-*.json

--- a/src/core/events/interactionCreate.js
+++ b/src/core/events/interactionCreate.js
@@ -64,6 +64,14 @@ const {
     handleBotMessageInteraction,
     BOT_MESSAGE_CUSTOM_ID_PREFIX,
 } = require('../../modules/botMessage');
+const {
+    handleMysteryInteraction,
+    MYSTERY_CUSTOM_ID_PREFIX,
+} = require('../../modules/mystery/services/interactionHandler');
+const {
+    handleNamePoolInteraction,
+    NAME_POOL_CUSTOM_ID_PREFIX,
+} = require('../../modules/mystery/services/namePoolManager');
 
 const { checkFormPermission, getFormPermissionDeniedMessage } = require('../../core/utils/permissionManager');
 const { getFormPermissionSettings } = require('../../core/utils/database');
@@ -156,6 +164,16 @@ async function interactionCreateHandler(interaction) {
             // === 机器人消息管理（优先短路，避免与其它模块前缀冲突） ===
             if (interaction.customId.startsWith(BOT_MESSAGE_CUSTOM_ID_PREFIX)) {
                 await handleBotMessageInteraction(interaction);
+                return;
+            }
+
+            if (interaction.customId.startsWith(NAME_POOL_CUSTOM_ID_PREFIX)) {
+                await handleNamePoolInteraction(interaction);
+                return;
+            }
+
+            if (interaction.customId.startsWith(MYSTERY_CUSTOM_ID_PREFIX)) {
+                await handleMysteryInteraction(interaction);
                 return;
             }
 
@@ -528,6 +546,11 @@ async function interactionCreateHandler(interaction) {
                 return;
             }
 
+            if (interaction.customId.startsWith(NAME_POOL_CUSTOM_ID_PREFIX)) {
+                await handleNamePoolInteraction(interaction);
+                return;
+            }
+
             if (interaction.customId === 'form_submission') {
                 // 表单提交处理
                 await processFormSubmission(interaction);
@@ -588,6 +611,22 @@ async function interactionCreateHandler(interaction) {
         
         // 处理选择菜单（包含 String/Role/Channel 等所有 SelectMenu）
         if (interaction.isAnySelectMenu()) {
+            if (
+                interaction.isStringSelectMenu()
+                && interaction.customId.startsWith(NAME_POOL_CUSTOM_ID_PREFIX)
+            ) {
+                await handleNamePoolInteraction(interaction);
+                return;
+            }
+
+            if (
+                interaction.isStringSelectMenu()
+                && interaction.customId.startsWith(MYSTERY_CUSTOM_ID_PREFIX)
+            ) {
+                await handleMysteryInteraction(interaction);
+                return;
+            }
+
             if (interaction.customId.startsWith('submission_action_')) {
                 // 稿件管理操作选择
                 await processSubmissionAction(interaction);

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -162,11 +162,12 @@ const viewMyControlledInviteStatusCommand = require('../modules/controlledInvite
 
 // Discord 安全措施（邀请暂停托管）
 const { startSafetySetupSystem } = require('../modules/safetySetup');
-const closeDoorCommand = require('../modules/safetySetup/commands/closeDoor');
-const openDoorCommand = require('../modules/safetySetup/commands/openDoor');
 
 // 神秘指令娱乐系统
 const mysteryCommand = require('../modules/mystery/commands/mysteryCommand');
+const manageCommand = require('../modules/mystery/commands/manageCommand');
+const { mysteryGuildMemberRemoveHandler } = require('../modules/mystery/events/guildMemberRemove');
+const { mysteryGuildMemberUpdateHandler } = require('../modules/mystery/events/guildMemberUpdate');
 
 const DISCORD_REST_TIMEOUT_MS = (() => {
     const n = Number(process.env.DISCORD_REST_TIMEOUT_MS);
@@ -330,9 +331,8 @@ client.commands.set(controlledInviteParamsCommand.data.name, controlledInvitePar
 client.commands.set(controlledInviteToggleCommand.data.name, controlledInviteToggleCommand);
 client.commands.set(viewMyControlledInviteStatusCommand.data.name, viewMyControlledInviteStatusCommand);
 
-// Discord 安全措施
-client.commands.set(closeDoorCommand.data.name, closeDoorCommand);
-client.commands.set(openDoorCommand.data.name, openDoorCommand);
+// Discord 安全措施与神秘管理工具（统一为唯一 /管理）
+client.commands.set(manageCommand.data.name, manageCommand);
 
 // 神秘指令娱乐系统
 client.commands.set(mysteryCommand.data.name, mysteryCommand);
@@ -414,6 +414,8 @@ client.on(Events.GuildMemberAdd, controlledInviteGuildMemberAddHandler);
 client.on(Events.GuildMemberRemove, roleSyncGuildMemberRemoveHandler);
 client.on(Events.GuildMemberUpdate, roleSyncGuildMemberUpdateHandler);
 client.on(Events.GuildRoleDelete, roleSyncGuildRoleDeleteHandler);
+client.on(Events.GuildMemberRemove, mysteryGuildMemberRemoveHandler);
+client.on(Events.GuildMemberUpdate, mysteryGuildMemberUpdateHandler);
 
 function normalizeDiscordToken(raw) {
     if (!raw) return '';

--- a/src/modules/mystery/commands/manageCommand.js
+++ b/src/modules/mystery/commands/manageCommand.js
@@ -1,0 +1,77 @@
+const { MessageFlags, SlashCommandBuilder } = require('discord.js');
+const {
+    checkAdminPermission,
+    getPermissionDeniedMessage,
+} = require('../../../core/utils/permissionManager');
+const { openNamePoolManager } = require('../services/namePoolManager');
+const { executeCloseDoor } = require('../../safetySetup/commands/closeDoor');
+const { executeOpenDoor } = require('../../safetySetup/commands/openDoor');
+
+function buildData() {
+    return new SlashCommandBuilder()
+        .setName('管理')
+        .setDescription('管理服务器与神秘指令设置')
+        .addSubcommand(subcommand => subcommand
+            .setName('神秘名字库')
+            .setDescription('管理全 Bot 共用的神秘昵称名字库'))
+        .addSubcommand(subcommand => subcommand
+            .setName('关门')
+            .setDescription('暂停服务器邀请并交由 Bot 自动续期托管')
+            .addStringOption(option => option
+                .setName('恢复时间')
+                .setDescription('可选，北京时间 YYYY-MM-DD HH:mm；不填则仅 /管理 开门 才恢复')
+                .setRequired(false)))
+        .addSubcommand(subcommand => subcommand
+            .setName('开门')
+            .setDescription('停止邀请暂停托管并恢复服务器邀请'));
+}
+
+function createManageCommand({
+    openNamePoolManager: openNames = openNamePoolManager,
+    executeCloseDoor: closeDoor = executeCloseDoor,
+    executeOpenDoor: openDoor = executeOpenDoor,
+    checkPermission = checkAdminPermission,
+    permissionDeniedMessage = getPermissionDeniedMessage,
+} = {}) {
+    const data = buildData();
+
+    async function execute(interaction) {
+        if (!interaction.inGuild()) {
+            await interaction.reply({
+                content: '❌ 此命令只能在服务器中使用。',
+                flags: MessageFlags.Ephemeral,
+            });
+            return;
+        }
+        if (!checkPermission(interaction.member)) {
+            await interaction.reply({
+                content: permissionDeniedMessage(),
+                flags: MessageFlags.Ephemeral,
+            });
+            return;
+        }
+
+        const subcommand = interaction.options.getSubcommand(false);
+        if (subcommand === '神秘名字库') {
+            await openNames(interaction);
+        } else if (subcommand === '关门') {
+            await closeDoor(interaction);
+        } else if (subcommand === '开门') {
+            await openDoor(interaction);
+        } else {
+            await interaction.reply({
+                content: '❌ 未知的管理指令。',
+                flags: MessageFlags.Ephemeral,
+            });
+        }
+    }
+
+    return { data, execute };
+}
+
+const command = createManageCommand();
+
+module.exports = {
+    ...command,
+    createManageCommand,
+};

--- a/src/modules/mystery/commands/mysteryCommand.js
+++ b/src/modules/mystery/commands/mysteryCommand.js
@@ -10,23 +10,38 @@ const {
     acquireInFlight,
     releaseInFlight,
 } = require('../utils/cooldown');
+const gameManager = require('../services/mysteryGameManager');
+const { startRoulette } = require('../services/rouletteGame');
+const { startBomb } = require('../services/bombGame');
+const { startDuel } = require('../services/duelGame');
+const { getNames } = require('../services/namePoolStore');
 
 const SUBCOMMAND_SELF_TIMEOUT = '自刎归天';
 const SUBCOMMAND_RANDOM_NICKNAME = '取名字好麻烦';
+const SUBCOMMAND_ROULETTE = '运气轮盘';
+const SUBCOMMAND_BOMB = '传炸弹';
+const SUBCOMMAND_DUEL = '死斗';
+const VALID_SUBCOMMANDS = [
+    SUBCOMMAND_SELF_TIMEOUT,
+    SUBCOMMAND_RANDOM_NICKNAME,
+    SUBCOMMAND_ROULETTE,
+    SUBCOMMAND_BOMB,
+    SUBCOMMAND_DUEL,
+];
+const IN_MEMORY_COOLDOWN_SUBCOMMANDS = new Set([
+    SUBCOMMAND_SELF_TIMEOUT,
+    SUBCOMMAND_RANDOM_NICKNAME,
+    SUBCOMMAND_ROULETTE,
+    SUBCOMMAND_DUEL,
+]);
 const SELF_TIMEOUT_DURATION_MS = 5 * 60 * 1000;
 const SELF_TIMEOUT_REASON = '神秘指令：自刎归天';
 const COOLDOWN_MESSAGE = '⏳ **这个神秘指令还在冷却中**， **30分钟后才能再次使用**。';
 const TIMEOUT_FAILURE_MESSAGE = '❌ 神秘力量失效了，我无法对你施加禁言。\n可能是机器人权限或身份组层级不足。';
 const NICKNAME_FAILURE_MESSAGE = '❌ 名字取好了，但我改不了你的昵称。\n可能是机器人权限或身份组层级不足。';
 const GENERIC_FAILURE_MESSAGE = '❌ 处理神秘指令时出现错误，请稍后重试。';
-
-const NAME_POOL = [
-    '我是奶人', '奶奶的龙', '铁血旅程派', '铁血类脑派', '权蛆', 'D喵梦男', 'D喵梦女',
-    '大狗叫！', '猪猪之王', '类脑自研文爱AI', '赛博街溜子', '名字被狗吃了',
-    '管理组重点观察对象', '用户名涉嫌违规', '类脑最纯洁之人', '类脑最淫乱之人', '基米',
-    '我不是gay', '我是好女孩吗', '类脑第一深情', '名字已被夺舍', '疑似真人',
-    '别问我为什么叫这个', '嘉豪本豪', '我现在后悔还来得及吗', '嘉豪',
-];
+const PLAYER_BUSY_MESSAGE = '🚫 **一心不能二用。**\n你现在已经在一场神秘游戏里，先把那边活着玩完再说。';
+const initiationQueues = new Map();
 
 const data = new SlashCommandBuilder()
     .setName('神秘指令')
@@ -36,7 +51,20 @@ const data = new SlashCommandBuilder()
         .setDescription('让自己暂时归天五分钟'))
     .addSubcommand(subcommand => subcommand
         .setName(SUBCOMMAND_RANDOM_NICKNAME)
-        .setDescription('随机决定自己的服务器昵称'));
+        .setDescription('随机决定自己的服务器昵称'))
+    .addSubcommand(subcommand => subcommand
+        .setName(SUBCOMMAND_ROULETTE)
+        .setDescription('参加一场紧张刺激的运气轮盘'))
+    .addSubcommand(subcommand => subcommand
+        .setName(SUBCOMMAND_BOMB)
+        .setDescription('参加一场紧张刺激的传炸弹游戏'))
+    .addSubcommand(subcommand => subcommand
+        .setName(SUBCOMMAND_DUEL)
+        .setDescription('向一名成员发起死斗，或等待其他人应战')
+        .addUserOption(option => option
+            .setName('对手')
+            .setDescription('指定要挑战的对手（留空则公开招募）')
+            .setRequired(false)));
 
 function botHasPermission(interaction, permission) {
     return interaction.guild.members.me?.permissions?.has(permission) === true;
@@ -72,6 +100,8 @@ async function replyWithUnexpectedError(interaction) {
     try {
         if (interaction.deferred) {
             await replacePublicDeferWithPrivateFailure(interaction, GENERIC_FAILURE_MESSAGE);
+        } else if (interaction.replied) {
+            await interaction.followUp({ content: GENERIC_FAILURE_MESSAGE, flags: MessageFlags.Ephemeral });
         } else {
             await interaction.reply({ content: GENERIC_FAILURE_MESSAGE, flags: MessageFlags.Ephemeral });
         }
@@ -95,17 +125,18 @@ async function executeSelfTimeout(interaction) {
     };
 }
 
-function selectRandomNickname(currentDisplayName) {
-    let selectedName = NAME_POOL[Math.floor(Math.random() * NAME_POOL.length)];
-    if (selectedName === currentDisplayName) {
-        selectedName = NAME_POOL[Math.floor(Math.random() * NAME_POOL.length)];
-    }
-    return selectedName;
+function selectRandomNickname(names, currentDisplayName) {
+    const candidates = names.length > 1
+        ? names.filter(name => name !== currentDisplayName)
+        : names;
+    const effectiveCandidates = candidates.length > 0 ? candidates : names;
+    return effectiveCandidates[Math.floor(Math.random() * effectiveCandidates.length)];
 }
 
 async function executeRandomNickname(interaction) {
     const member = interaction.member;
-    const selectedName = selectRandomNickname(member.displayName);
+    const names = await getNames();
+    const selectedName = selectRandomNickname(names, member.displayName);
     try {
         await member.setNickname(selectedName);
     } catch (error) {
@@ -143,36 +174,83 @@ async function sendSuccessPanels(interaction, result) {
     }
 }
 
+async function startMultiplayerGame(interaction, subcommand) {
+    if (subcommand === SUBCOMMAND_ROULETTE) {
+        return startRoulette(interaction);
+    }
+    if (subcommand === SUBCOMMAND_BOMB) {
+        return startBomb(interaction);
+    }
+    return startDuel(interaction, interaction.options.getUser('对手'));
+}
+
+async function acquireInitiationLock(guildId, userId) {
+    const key = `${guildId}:${userId}`;
+    const previous = initiationQueues.get(key) || Promise.resolve();
+    let releaseGate;
+    const gate = new Promise(resolve => {
+        releaseGate = resolve;
+    });
+    initiationQueues.set(key, gate);
+    await previous;
+
+    let released = false;
+    return () => {
+        if (released) return;
+        released = true;
+        releaseGate();
+        if (initiationQueues.get(key) === gate) {
+            initiationQueues.delete(key);
+        }
+    };
+}
+
 async function execute(interaction) {
     let guildId = null;
     let userId = interaction.user?.id || 'unknown';
     let subcommand = null;
     let lockAcquired = false;
+    let releaseInitiationLock = null;
     try {
         if (!interaction.inGuild()) {
             await interaction.reply({ content: '❌ 此指令只能在服务器中使用。', flags: MessageFlags.Ephemeral });
             return;
         }
         subcommand = interaction.options.getSubcommand(false);
-        const validSubcommands = [SUBCOMMAND_SELF_TIMEOUT, SUBCOMMAND_RANDOM_NICKNAME];
-        if (!validSubcommands.includes(subcommand)) {
+        if (!VALID_SUBCOMMANDS.includes(subcommand)) {
             await interaction.reply({ content: '❌ 未知的神秘指令。', flags: MessageFlags.Ephemeral });
             return;
         }
         guildId = interaction.guild.id;
         userId = interaction.user.id;
-        if (isOnCooldown(guildId, userId, subcommand)) {
-            await interaction.reply({ content: COOLDOWN_MESSAGE, flags: MessageFlags.Ephemeral });
-            return;
-        }
         lockAcquired = acquireInFlight(guildId, userId, subcommand);
         if (!lockAcquired) {
             await interaction.reply({ content: COOLDOWN_MESSAGE, flags: MessageFlags.Ephemeral });
             return;
         }
+        releaseInitiationLock = await acquireInitiationLock(guildId, userId);
+        if (gameManager.getPlayerGame(guildId, userId)) {
+            await interaction.reply({ content: PLAYER_BUSY_MESSAGE, flags: MessageFlags.Ephemeral });
+            return;
+        }
+        const usesInMemoryCooldown = IN_MEMORY_COOLDOWN_SUBCOMMANDS.has(subcommand);
+        if (usesInMemoryCooldown && isOnCooldown(guildId, userId, subcommand)) {
+            await interaction.reply({ content: COOLDOWN_MESSAGE, flags: MessageFlags.Ephemeral });
+            return;
+        }
+        const isMultiplayer = subcommand === SUBCOMMAND_ROULETTE
+            || subcommand === SUBCOMMAND_BOMB
+            || subcommand === SUBCOMMAND_DUEL;
+        if (isMultiplayer) {
+            const started = await startMultiplayerGame(interaction, subcommand);
+            if (started && usesInMemoryCooldown) {
+                startCooldown(guildId, userId, subcommand);
+            }
+            return;
+        }
         const preflightFailure = getPreflightFailure(interaction, subcommand);
         if (preflightFailure) {
-            await interaction.reply({ content: preflightFailure, flags: MessageFlags.Ephemeral });
+            await interaction.reply({ content: preflightFailure });
             return;
         }
         await interaction.deferReply();
@@ -183,7 +261,7 @@ async function execute(interaction) {
             const failureMessage = subcommand === SUBCOMMAND_SELF_TIMEOUT
                 ? TIMEOUT_FAILURE_MESSAGE
                 : NICKNAME_FAILURE_MESSAGE;
-            await replacePublicDeferWithPrivateFailure(interaction, failureMessage);
+            await interaction.editReply({ content: failureMessage });
             return;
         }
         startCooldown(guildId, userId, subcommand);
@@ -195,6 +273,7 @@ async function execute(interaction) {
         );
         await replyWithUnexpectedError(interaction);
     } finally {
+        releaseInitiationLock?.();
         if (lockAcquired) releaseInFlight(guildId, userId, subcommand);
     }
 }

--- a/src/modules/mystery/events/guildMemberRemove.js
+++ b/src/modules/mystery/events/guildMemberRemove.js
@@ -1,0 +1,41 @@
+const gameManager = require('../services/mysteryGameManager');
+
+function getMemberIds(member) {
+    const guildId = member?.guild?.id;
+    const memberId = member?.id;
+    const userId = member?.user?.id;
+
+    if (
+        typeof guildId !== 'string'
+        || guildId.trim().length === 0
+        || guildId !== guildId.trim()
+        || typeof memberId !== 'string'
+        || memberId.trim().length === 0
+        || memberId !== memberId.trim()
+        || typeof userId !== 'string'
+        || userId.trim().length === 0
+        || userId !== userId.trim()
+        || memberId !== userId
+    ) {
+        return null;
+    }
+
+    return { guildId, userId };
+}
+
+async function mysteryGuildMemberRemoveHandler(member) {
+    const ids = getMemberIds(member);
+    if (!ids) {
+        return;
+    }
+
+    try {
+        await gameManager.handleGuildMemberRemove(member);
+    } catch (_) {
+        console.error(
+            `[Mystery] member invalidation failed guildId=${ids.guildId} userId=${ids.userId} reason=member-remove`
+        );
+    }
+}
+
+module.exports = { mysteryGuildMemberRemoveHandler };

--- a/src/modules/mystery/events/guildMemberUpdate.js
+++ b/src/modules/mystery/events/guildMemberUpdate.js
@@ -1,0 +1,60 @@
+const gameManager = require('../services/mysteryGameManager');
+
+function getMemberIds(member) {
+    const guildId = member?.guild?.id;
+    const memberId = member?.id;
+    const userId = member?.user?.id;
+
+    if (
+        typeof guildId !== 'string'
+        || guildId.trim().length === 0
+        || guildId !== guildId.trim()
+        || typeof memberId !== 'string'
+        || memberId.trim().length === 0
+        || memberId !== memberId.trim()
+        || typeof userId !== 'string'
+        || userId.trim().length === 0
+        || userId !== userId.trim()
+        || memberId !== userId
+    ) {
+        return null;
+    }
+
+    return { guildId, userId };
+}
+
+function isFiniteTimestamp(value) {
+    return typeof value === 'number' && Number.isFinite(value);
+}
+
+async function mysteryGuildMemberUpdateHandler(oldMember, newMember) {
+    const oldIds = getMemberIds(oldMember);
+    const newIds = getMemberIds(newMember);
+    if (
+        !oldIds
+        || !newIds
+        || oldIds.guildId !== newIds.guildId
+        || oldIds.userId !== newIds.userId
+    ) {
+        return;
+    }
+
+    const now = Date.now();
+    const oldTimeout = oldMember.communicationDisabledUntilTimestamp;
+    const newTimeout = newMember.communicationDisabledUntilTimestamp;
+    const oldIsActive = isFiniteTimestamp(oldTimeout) && oldTimeout > now;
+    const newIsActive = isFiniteTimestamp(newTimeout) && newTimeout > now;
+    if (oldIsActive || !newIsActive) {
+        return;
+    }
+
+    try {
+        await gameManager.handleGuildMemberUpdate(oldMember, newMember);
+    } catch (_) {
+        console.error(
+            `[Mystery] member invalidation failed guildId=${newIds.guildId} userId=${newIds.userId} reason=timeout`
+        );
+    }
+}
+
+module.exports = { mysteryGuildMemberUpdateHandler };

--- a/src/modules/mystery/services/bombGame.js
+++ b/src/modules/mystery/services/bombGame.js
@@ -1,0 +1,1194 @@
+const { randomUUID } = require('node:crypto');
+const {
+    ActionRowBuilder,
+    ButtonBuilder,
+    ButtonStyle,
+    EmbedBuilder,
+    MessageFlags,
+    StringSelectMenuBuilder,
+} = require('discord.js');
+const gameManager = require('./mysteryGameManager');
+const defaultCooldownStore = require('../utils/bombCooldownStore');
+
+const RECRUITMENT_DURATION_MS = 3 * 60 * 1000;
+const BOMB_TIMEOUT_DURATION_MS = 5 * 60 * 1000;
+const BOMB_TIMEOUT_REASON = '神秘指令：传炸弹';
+const MIN_PARTICIPANTS = 3;
+const MAX_PARTICIPANTS = 8;
+const cooldownLoadPromises = new WeakMap();
+const PANEL_SKIPPED = Symbol('panel-skipped');
+
+const PLAYER_BUSY_MESSAGE = '🚫 **一心不能二用。**\n你现在已经在一场神秘游戏里，先把那边活着玩完再说。';
+const CHANNEL_BUSY_MESSAGE = '🎮 **这里已经有一场游戏在进行了。**\n等当前游戏结束后再开新的吧。';
+const COOLDOWN_MESSAGE = '⏳ **这个神秘指令还在冷却中**， **30分钟后才能再次使用**。';
+const TIMEOUT_BLOCKED_MESSAGE = '💣 **炸弹拒绝了你。**\n你当前还在禁言，暂时无法参加。';
+const INVALID_MEMBER_MESSAGE = '⚠️ **你现在无法参加这场传炸弹游戏。**';
+const EXPIRED_MESSAGE = '⌛ **这场传炸弹游戏已经结束或失效了。**';
+const DUPLICATE_MESSAGE = '👀 **你已经在车上了。**\n再点也不会多一条命。';
+const FULL_MESSAGE = '💣 **这场传炸弹已经满员了。**';
+const JOINED_MESSAGE = '💣 **炸弹已经记住你了。**\n\n你已成功加入本局。\n现在退出已经来不及了。';
+const NOT_HOLDER_MESSAGE = '✋ **炸弹又不在你手里。**\n别这么积极。';
+const TOO_FAST_MESSAGE = '⏳ **手别这么快。**\n炸弹刚到你手里，等一下再扔。';
+const TARGET_INVALID_MESSAGE = '⚠️ **这个人现在接不了炸弹。**\n请重新选择一名参与者。';
+const TIMEOUT_FAILURE_LINE = '🛡️ **但禁言被神秘力量阻挡，未能生效。**';
+
+const PASS_COPY_BUILDERS = [
+    (from, to) => `💨 **<@${from}> 毫不犹豫地把炸弹塞给了 <@${to}>。**\n看得出来，这段友情不太牢固。`,
+    (from, to) => `📦 **<@${from}> 发起了一笔特殊快递。**\n收件人：<@${to}>\n包裹内容：💣`,
+    (from, to) => `🤝 **<@${from}> 十分友善地把炸弹交给了 <@${to}>。**\n<@${to}> 应该会很感动。`,
+    (from, to) => `🎁 **<@${from}> 给 <@${to}> 准备了一份惊喜。**\n就是这个惊喜一直在滴滴响。`,
+    (from, to) => `🏃 **<@${from}> 把炸弹往 <@${to}> 怀里一塞，转身就跑。**\n动作十分熟练。`,
+    (from, to) => `💣 **<@${from}>：这个我不要了，你拿着。**\n<@${to}>：？`,
+    (from, to) => `🫴 **<@${from}> 将烫手山芋正式移交给 <@${to}>。**\n当然，这个比山芋稍微危险一点。`,
+    (from, to) => `🧾 **责任转移成功。**\n当前责任人：**<@${to}>**\n前任责任人：<@${from}>`,
+    (from, to) => `🚚 **<@${from}> 的炸弹已成功送达。**\n<@${to}>，记得五星好评。`,
+    (from, to) => `🥰 **<@${from}> 想了想，还是觉得好东西应该和 <@${to}> 分享。**\n💣`,
+    (from, to) => `🧠 **经过深思熟虑，<@${from}> 决定让 <@${to}> 来处理这个问题。**\n非常合理。`,
+    (from, to) => `📞 **<@${from}>：喂？这里有你的快递。**\n<@${to}>：我没买东西啊。\n💣`,
+    (from, to) => `🏅 **恭喜 <@${to}> 成为本轮最新炸弹持有者。**\n<@${from}> 已安全下车。`,
+    (from, to) => `🫡 **<@${from}> 完成战略撤退。**\n炸弹现已由 <@${to}> 接管。`,
+    (from, to) => `👋 **<@${from}> 和炸弹进行了友好告别。**\n然后把它留给了 <@${to}>。`,
+];
+
+function logDiscordFailure(game, action, error, userId = 'system') {
+    console.error(
+        `[MysteryBomb] Discord API 失败 (guild=${game?.guildId || 'unknown'}, game=${game?.id || 'unknown'}, user=${userId}, action=${action}):`,
+        error
+    );
+}
+
+function nowFor(game) {
+    return typeof game?.now === 'function' ? game.now() : Date.now();
+}
+
+function randomFor(game) {
+    return typeof game?.random === 'function' ? game.random() : Math.random();
+}
+
+function randomIndex(length, randomValue) {
+    return Math.min(length - 1, Math.max(0, Math.floor(randomValue * length)));
+}
+
+function randomExplosionDelayMs(random = Math.random) {
+    return (30 + randomIndex(91, random())) * 1000;
+}
+
+function makeEmbed(description) {
+    return new EmbedBuilder().setDescription(description);
+}
+
+function recruitmentDescription(game, participantCount = game.participantIds.length) {
+    const startsAt = Math.floor(game.recruitmentEndsAt / 1000);
+    return [
+        '💣 **有人捡到了一颗来历不明的炸弹**',
+        '',
+        `<@${game.initiatorId}> 不知道从哪里搞来了一颗正在倒计时的炸弹。`,
+        '',
+        '**游戏规则**',
+        '- 本游戏为自愿参加',
+        '- 最少 **3 人**，最多 **8 人**',
+        '- 满 **8 人**立即开始',
+        '- 未满 8 人将在 **3 分钟后**尝试开始',
+        '- 开局后炸弹会随机出现在一名玩家手中',
+        '- 拿到炸弹的人可以把它传给其他参与者',
+        '- 炸弹什么时候爆炸，没人知道',
+        '- 爆炸时持有炸弹的人将被 **禁言 5 分钟**',
+        '',
+        `**当前人数：${participantCount} / 8**`,
+        `⏳ **预计开始：<t:${startsAt}:R>**`,
+    ].join('\n');
+}
+
+function cancellationDescription() {
+    return '💣 **炸弹：所以没人陪我玩是吧？**\n\n3 分钟过去了，人数不足，本局自动取消。';
+}
+
+function recruitmentClosedDescription(count) {
+    return [
+        '🔒 **报名已结束**',
+        '',
+        '本局传炸弹已经开始。',
+        '',
+        `**最终参与人数：${count} 人**`,
+        '',
+        '招募已关闭，无法继续加入。',
+    ].join('\n');
+}
+
+function firstHolderDescription(snapshot) {
+    return [
+        `💣 **恭喜 <@${snapshot.currentHolderId}> 成为第一位倒霉蛋。**`,
+        '',
+        '这东西现在归你了。',
+        '',
+        '**参与者**',
+        snapshot.participantIds.map(userId => `<@${userId}>`).join(' · '),
+        '',
+        `**当前持有者：<@${snapshot.currentHolderId}>**`,
+        '**已传递：0 次**',
+    ].join('\n');
+}
+
+function passDescription(fromId, toId, count, randomValue) {
+    const copy = PASS_COPY_BUILDERS[randomIndex(PASS_COPY_BUILDERS.length, randomValue)](fromId, toId);
+    return `${copy}\n\n**当前持有者：<@${toId}>**\n**已传递：${count} 次**`;
+}
+
+function explosionDescription(game, timeoutFailed) {
+    const durationSeconds = Math.max(
+        0,
+        Math.floor(((game.explosionClaimedAt ?? nowFor(game)) - game.startedAt) / 1000)
+    );
+    const lines = [
+        '💥 **BOOOOOOM！！**',
+        '',
+        `很遗憾，炸弹最终选择了 <@${game.finalHolderId}>。`,
+        '',
+        '奖励：**禁言 5 分钟。**',
+        '',
+        '**本局统计**',
+        `- 总传递次数：**${game.passCount} 次**`,
+        `- 本局持续时间：**${durationSeconds} 秒**`,
+        `- 最终持有者：<@${game.finalHolderId}>`,
+    ];
+    if (timeoutFailed) lines.push('', TIMEOUT_FAILURE_LINE);
+    return lines.join('\n');
+}
+
+function cancellationAfterInvalidationDescription() {
+    return [
+        '🧯 **这局玩不下去了。**',
+        '',
+        '由于有参与者离开服务器，当前剩余人数已不足 **3 人**。',
+        '',
+        '**本局游戏自动取消。**',
+        '',
+        '炸弹今天算是捡回一条命。',
+    ].join('\n');
+}
+
+function reassignmentDescription(userId, holderId, reason) {
+    if (reason === 'timeout' || reason === 'member-timeout') {
+        return [
+            `🔇 **<@${userId}> 突然失去了说话的资格。**`,
+            '',
+            '他已从本局游戏中移除。',
+            '',
+            `💣 炸弹随机落到了 **<@${holderId}>** 手里。`,
+        ].join('\n');
+    }
+    return [
+        `🚪 **<@${userId}> 带着跑路的想法离开了服务器。**`,
+        '',
+        '可惜炸弹不能就这么消失。',
+        '',
+        `💣 炸弹随机落到了 **<@${holderId}>** 手里。`,
+    ].join('\n');
+}
+
+function joinRow(gameId, disabled = false) {
+    return new ActionRowBuilder().addComponents(
+        new ButtonBuilder()
+            .setCustomId(`mystery_bomb_join:${gameId}`)
+            .setLabel('💣 接过炸弹')
+            .setStyle(ButtonStyle.Primary)
+            .setDisabled(disabled)
+    );
+}
+
+function passRow(gameId, messageToken, disabled = false) {
+    return new ActionRowBuilder().addComponents(
+        new ButtonBuilder()
+            .setCustomId(`mystery_bomb_pass:${gameId}:${messageToken}`)
+            .setLabel('💣 传炸弹')
+            .setStyle(ButtonStyle.Danger)
+            .setDisabled(disabled)
+    );
+}
+
+function recruitmentPayload(game, disabled = false, description = recruitmentDescription(game)) {
+    return {
+        embeds: [makeEmbed(description)],
+        components: [joinRow(game.id, disabled)],
+    };
+}
+
+function bombPayload(gameId, messageToken, description, disabled = false) {
+    return {
+        embeds: [makeEmbed(description)],
+        components: [passRow(gameId, messageToken, disabled)],
+    };
+}
+
+function isActivelyTimedOut(member, now = Date.now()) {
+    return Number(member?.communicationDisabledUntilTimestamp) > now;
+}
+
+function isValidHumanMember(member, now = Date.now()) {
+    return Boolean(member?.id && member.user && !member.user.bot && !isActivelyTimedOut(member, now));
+}
+
+async function safeFetchMember(game, userId) {
+    try {
+        const member = await game.guild?.members?.fetch(userId);
+        game.memberById?.set(userId, member);
+        return member;
+    } catch (error) {
+        logDiscordFailure(game, 'fetch-member', error, userId);
+        return null;
+    }
+}
+
+async function ensureCooldownStoreLoaded(store, game, userId) {
+    if (!store || typeof store.load !== 'function') return true;
+    let loadPromise = cooldownLoadPromises.get(store);
+    if (!loadPromise) {
+        loadPromise = Promise.resolve().then(() => store.load());
+        cooldownLoadPromises.set(store, loadPromise);
+    }
+    try {
+        await loadPromise;
+        return true;
+    } catch (error) {
+        logDiscordFailure(game, 'cooldown-load', error, userId);
+        return false;
+    }
+}
+
+async function deferPublicCommand(interaction, game) {
+    if (interaction.deferred || interaction.replied) return true;
+    if (typeof interaction.deferReply !== 'function') return false;
+    try {
+        await interaction.deferReply();
+        return true;
+    } catch (error) {
+        logDiscordFailure(game, 'defer-command-reply', error, interaction.user?.id);
+        return false;
+    }
+}
+
+async function failDeferredStart(interaction, content, game) {
+    try {
+        await interaction.deleteReply?.();
+    } catch (error) {
+        logDiscordFailure(game, 'delete-command-placeholder', error, interaction.user?.id);
+    }
+    try {
+        await interaction.followUp?.({ content, flags: MessageFlags.Ephemeral });
+    } catch (error) {
+        logDiscordFailure(game, 'command-failure-follow-up', error, interaction.user?.id);
+    }
+}
+
+async function safeEphemeralReply(interaction, content, game, components) {
+    const response = { content };
+    if (components) response.components = components;
+    try {
+        if (interaction.deferred && !interaction.replied && typeof interaction.editReply === 'function') {
+            await interaction.editReply(response);
+        } else if (interaction.replied) {
+            await interaction.followUp?.({ ...response, flags: MessageFlags.Ephemeral });
+        } else {
+            await interaction.reply?.({ ...response, flags: MessageFlags.Ephemeral });
+        }
+    } catch (error) {
+        logDiscordFailure(game, 'ephemeral-reply', error, interaction.user?.id);
+    }
+}
+
+async function deferEphemeralComponent(interaction, game) {
+    if (interaction.deferred || interaction.replied || typeof interaction.deferReply !== 'function') {
+        return true;
+    }
+    try {
+        await interaction.deferReply({ flags: MessageFlags.Ephemeral });
+        return true;
+    } catch (error) {
+        logDiscordFailure(game, 'defer-component-reply', error, interaction.user?.id);
+        return false;
+    }
+}
+
+async function safeEdit(message, payload, game, action) {
+    if (typeof message?.edit !== 'function') return false;
+    try {
+        await message.edit(payload);
+        return true;
+    } catch (error) {
+        logDiscordFailure(game, action, error);
+        return false;
+    }
+}
+
+async function safeSend(game, payload, action) {
+    try {
+        return await game.channel?.send(payload) || null;
+    } catch (error) {
+        logDiscordFailure(game, action, error);
+        return null;
+    }
+}
+
+function queuePanelWrite(game, operation) {
+    const previous = game.panelWriteQueue || Promise.resolve();
+    const queued = previous
+        .catch(error => logDiscordFailure(game, 'panel-write-queue', error))
+        .then(operation)
+        .catch(error => {
+            logDiscordFailure(game, 'panel-write-queue', error);
+            return false;
+        });
+    game.panelWriteQueue = queued;
+    return queued;
+}
+
+function queuePublicWrite(game, operation) {
+    const previous = game.publicWriteQueue || Promise.resolve();
+    const queued = previous
+        .catch(error => logDiscordFailure(game, 'public-write-queue', error))
+        .then(operation)
+        .catch(error => {
+            logDiscordFailure(game, 'public-write-queue', error);
+            return null;
+        });
+    game.publicWriteQueue = queued;
+    return queued;
+}
+
+async function disableBombMessage(game, message, token) {
+    if (!message) return false;
+    return safeEdit(message, {
+        components: [passRow(game.id, token, true)],
+    }, game, 'disable-bomb-message');
+}
+
+async function disableAllComponents(game) {
+    try {
+        await game.panelWriteQueue;
+        await game.publicWriteQueue;
+    } catch (error) {
+        logDiscordFailure(game, 'wait-component-writes', error);
+    }
+    await safeEdit(game.recruitmentMessage, {
+        components: [joinRow(game.id, true)],
+    }, game, 'disable-recruitment-message');
+    const messages = [...(game.bombMessages || [])];
+    await Promise.all(messages.map(message => disableBombMessage(
+        game,
+        message,
+        message.bombMessageToken ?? game.messageToken
+    )));
+}
+
+async function cleanupBombGame(game) {
+    if (!game || game.cleanupPromise) return game?.cleanupPromise;
+    let operation;
+    operation = (async () => {
+        await disableAllComponents(game);
+        await gameManager.cleanupGame(game);
+        game.state = 'ended';
+    })().catch(error => {
+        logDiscordFailure(game, 'cleanup', error);
+    });
+    game.cleanupPromise = operation;
+    return operation;
+}
+
+async function claimExplosion(game, currentTime) {
+    let claimed = false;
+    await gameManager.runExclusive(game, () => {
+        if (game.ended || game.state !== 'active' || currentTime < game.explodeAt) return;
+        game.state = 'exploding';
+        game.finalHolderId = game.currentHolderId;
+        game.explosionClaimedAt = currentTime;
+        claimed = true;
+    });
+    return claimed;
+}
+
+async function finishExplosion(game) {
+    if (game.explosionPromise) return game.explosionPromise;
+    let operation;
+    operation = (async () => {
+        await game.publicWriteQueue;
+        await disableAllComponents(game);
+
+        const resultMessage = await queuePublicWrite(game, () => safeSend(
+            game,
+            { embeds: [makeEmbed(explosionDescription(game, false))], components: [] },
+            'explosion-result'
+        ));
+        if (!resultMessage || resultMessage === PANEL_SKIPPED) {
+            await cleanupBombGame(game);
+            return;
+        }
+
+        let timeoutFailed = false;
+        const member = await safeFetchMember(game, game.finalHolderId);
+        if (!member?.moderatable || typeof member.timeout !== 'function') {
+            timeoutFailed = true;
+        } else {
+            try {
+                await member.timeout(BOMB_TIMEOUT_DURATION_MS, BOMB_TIMEOUT_REASON);
+            } catch (error) {
+                timeoutFailed = true;
+                logDiscordFailure(game, 'timeout-final-holder', error, game.finalHolderId);
+            }
+        }
+
+        if (timeoutFailed) {
+            const appended = await queuePublicWrite(game, () => safeEdit(
+                resultMessage,
+                { embeds: [makeEmbed(explosionDescription(game, true))], components: [] },
+                game,
+                'append-timeout-failure'
+            ));
+            if (!appended) {
+                await queuePublicWrite(game, () => safeSend(
+                    game,
+                    { content: TIMEOUT_FAILURE_LINE, components: [] },
+                    'timeout-failure-supplement'
+                ));
+            }
+        }
+        await cleanupBombGame(game);
+    })().catch(async error => {
+        logDiscordFailure(game, 'finish-explosion', error);
+        await cleanupBombGame(game);
+    });
+    game.explosionPromise = operation;
+    return operation;
+}
+
+async function explodeBomb(game, currentTime = nowFor(game)) {
+    if (await claimExplosion(game, currentTime)) {
+        await finishExplosion(game);
+        return true;
+    }
+    if (game.state === 'exploding') {
+        await finishExplosion(game);
+    }
+    return false;
+}
+
+function installExplosionTimer(game) {
+    if (game.ended || game.state !== 'active' || game.explosionTimer) return false;
+    const delay = Math.max(0, game.explodeAt - nowFor(game));
+    game.explosionTimer = setTimeout(() => {
+        void explodeBomb(game, nowFor(game))
+            .catch(error => logDiscordFailure(game, 'explosion-timer', error));
+    }, delay);
+    game.timers.add(game.explosionTimer);
+    return true;
+}
+
+async function abortAfterCriticalPanelFailure(game) {
+    let claimed = false;
+    await gameManager.runExclusive(game, () => {
+        if (game.ended || game.state === 'ended' || game.state === 'exploding') return;
+        game.state = 'cancelling';
+        claimed = true;
+    });
+    if (claimed) await cleanupBombGame(game);
+    return claimed;
+}
+
+async function cancelForTooFew(game, recruitment = false) {
+    const description = recruitment ? cancellationDescription() : cancellationAfterInvalidationDescription();
+    if (recruitment) {
+        await queuePanelWrite(game, () => safeEdit(
+            game.recruitmentMessage,
+            recruitmentPayload(game, true, description),
+            game,
+            'recruitment-cancelled'
+        ));
+    } else {
+        await queuePublicWrite(game, () => safeSend(
+            game,
+            { embeds: [makeEmbed(description)], components: [] },
+            'active-game-cancelled'
+        ));
+    }
+    await cleanupBombGame(game);
+}
+
+async function fetchValidParticipants(game, ids) {
+    const valid = [];
+    for (const userId of ids) {
+        const member = await safeFetchMember(game, userId);
+        if (isValidHumanMember(member)) valid.push(userId);
+    }
+    return valid;
+}
+
+async function finishRecruitment(game) {
+    let snapshot = [];
+    await gameManager.runExclusive(game, () => {
+        if (!game.ended && game.state === 'recruiting' && !game.recruitmentClosing) {
+            if (game.pendingJoinReservations?.size > 0) {
+                game.recruitmentStartRequested = true;
+                return;
+            }
+            game.recruitmentClosing = true;
+            snapshot = [...game.participantIds];
+        }
+    });
+    if (snapshot.length === 0) return false;
+
+    const validIds = await fetchValidParticipants(game, snapshot);
+    let outcome = null;
+    let activationSnapshot = null;
+    await gameManager.runExclusive(game, () => {
+        if (game.ended || game.state !== 'recruiting') return;
+        for (const userId of [...game.participantIds]) {
+            if (!validIds.includes(userId)) gameManager.removePlayer(game, userId);
+        }
+        if (game.participantIds.length < MIN_PARTICIPANTS) {
+            game.state = 'cancelling';
+            outcome = 'cancel';
+            return;
+        }
+
+        const currentTime = nowFor(game);
+        game.state = 'active';
+        game.startedAt = currentTime;
+        game.explodeAt = currentTime + randomExplosionDelayMs(game.random);
+        game.currentHolderId = game.participantIds[randomIndex(game.participantIds.length, randomFor(game))];
+        game.holderSince = currentTime;
+        game.passCount = 0;
+        game.messageToken = 1;
+        installExplosionTimer(game);
+        activationSnapshot = {
+            participantIds: [...game.participantIds],
+            currentHolderId: game.currentHolderId,
+            messageToken: game.messageToken,
+        };
+        outcome = 'active';
+    });
+
+    if (outcome === 'cancel') {
+        await cancelForTooFew(game, true);
+        return false;
+    }
+    if (outcome !== 'active') return false;
+
+    const firstPayload = bombPayload(
+        game.id,
+        activationSnapshot.messageToken,
+        firstHolderDescription(activationSnapshot)
+    );
+    const firstMessagePromise = queuePublicWrite(game, async () => {
+        if (
+            game.ended
+            || game.state !== 'active'
+            || game.messageToken !== activationSnapshot.messageToken
+            || game.currentHolderId !== activationSnapshot.currentHolderId
+        ) return PANEL_SKIPPED;
+        const message = await safeSend(game, firstPayload, 'first-holder-message');
+        if (message) {
+            message.bombMessageToken = activationSnapshot.messageToken;
+            game.currentMessage = message;
+            game.bombMessages.add(message);
+            game.messageByToken.set(activationSnapshot.messageToken, message);
+        }
+        return message;
+    });
+    const closePanelPromise = queuePanelWrite(game, () => safeEdit(
+        game.recruitmentMessage,
+        recruitmentPayload(
+            game,
+            true,
+            recruitmentClosedDescription(activationSnapshot.participantIds.length)
+        ),
+        game,
+        'close-recruitment'
+    ));
+    const firstMessage = await firstMessagePromise;
+    if (firstMessage === null) {
+        await abortAfterCriticalPanelFailure(game);
+        await closePanelPromise;
+        return false;
+    }
+    await closePanelPromise;
+    return firstMessage !== PANEL_SKIPPED;
+}
+
+async function startBomb(interaction) {
+    const userId = interaction.user?.id;
+    const guildId = interaction.guildId || interaction.guild?.id;
+    const channelId = interaction.channelId;
+    const cooldownStore = interaction.bombCooldownStore || defaultCooldownStore;
+    const provisionalGame = {
+        id: randomUUID(),
+        type: 'bomb',
+        guildId,
+        channelId,
+        guild: interaction.guild,
+        channel: interaction.channel,
+        initiatorId: userId,
+        participantIds: [userId],
+        state: 'recruiting',
+        random: Math.random,
+        now: Date.now,
+        timers: new Set(),
+        bombMessages: new Set(),
+        messageByToken: new Map(),
+        memberById: new Map(),
+        pendingJoinReservations: new Map(),
+        joinReservationVersion: 0,
+        recruitmentStartRequested: false,
+        panelWriteQueue: Promise.resolve(),
+        publicWriteQueue: Promise.resolve(),
+    };
+
+    if (!await deferPublicCommand(interaction, provisionalGame)) return false;
+
+    const member = await safeFetchMember(provisionalGame, userId);
+    if (!isValidHumanMember(member)) {
+        await failDeferredStart(
+            interaction,
+            isActivelyTimedOut(member) ? TIMEOUT_BLOCKED_MESSAGE : INVALID_MEMBER_MESSAGE,
+            provisionalGame
+        );
+        return false;
+    }
+    provisionalGame.memberById.set(userId, member);
+    if (!await ensureCooldownStoreLoaded(cooldownStore, provisionalGame, userId)) {
+        await failDeferredStart(interaction, INVALID_MEMBER_MESSAGE, provisionalGame);
+        return false;
+    }
+    try {
+        if (cooldownStore.isOnCooldown(guildId, userId)) {
+            await failDeferredStart(interaction, COOLDOWN_MESSAGE, provisionalGame);
+            return false;
+        }
+    } catch (error) {
+        logDiscordFailure(provisionalGame, 'cooldown-check', error, userId);
+        await failDeferredStart(interaction, INVALID_MEMBER_MESSAGE, provisionalGame);
+        return false;
+    }
+
+    let game;
+    provisionalGame.onMemberInvalidated = async (invalidMember, oldMember) => {
+        const invalidUserId = invalidMember?.id || invalidMember?.user?.id;
+        if (invalidUserId) {
+            await handleBombMemberInvalidated(
+                game,
+                invalidUserId,
+                oldMember ? 'timeout' : 'member-remove'
+            );
+        }
+    };
+    provisionalGame.disableComponents = () => {
+        void disableAllComponents(game);
+    };
+
+    const currentMember = await safeFetchMember(provisionalGame, userId);
+    if (!isValidHumanMember(currentMember)) {
+        await failDeferredStart(
+            interaction,
+            isActivelyTimedOut(currentMember) ? TIMEOUT_BLOCKED_MESSAGE : INVALID_MEMBER_MESSAGE,
+            provisionalGame
+        );
+        return false;
+    }
+    provisionalGame.memberById.set(userId, currentMember);
+    const created = gameManager.createGame(provisionalGame);
+    if (!created.ok) {
+        await failDeferredStart(
+            interaction,
+            created.reason === 'player' ? PLAYER_BUSY_MESSAGE : CHANNEL_BUSY_MESSAGE,
+            provisionalGame
+        );
+        return false;
+    }
+    game = created.game;
+    game.recruitmentEndsAt = nowFor(game) + RECRUITMENT_DURATION_MS;
+    game.recruitmentPayload = recruitmentPayload(game);
+
+    try {
+        const replyResult = await interaction.editReply(game.recruitmentPayload);
+        game.recruitmentMessage = replyResult?.resource?.message || replyResult;
+        if (typeof game.recruitmentMessage?.edit !== 'function' && typeof interaction.editReply === 'function') {
+            game.recruitmentMessage = { edit: payload => interaction.editReply(payload) };
+        }
+    } catch (error) {
+        logDiscordFailure(game, 'recruitment-panel', error, userId);
+        await cleanupBombGame(game);
+        await failDeferredStart(interaction, INVALID_MEMBER_MESSAGE, game);
+        return false;
+    }
+    try {
+        await cooldownStore.startCooldown(guildId, userId);
+    } catch (error) {
+        logDiscordFailure(game, 'cooldown-start', error, userId);
+    }
+    try {
+        const fetched = await interaction.fetchReply?.();
+        if (typeof fetched?.edit === 'function') game.recruitmentMessage = fetched;
+    } catch (error) {
+        logDiscordFailure(game, 'fetch-recruitment-panel', error, userId);
+        if (!game.recruitmentMessage) {
+            await cleanupBombGame(game);
+            return false;
+        }
+    }
+
+    game.recruitmentTimer = setTimeout(() => {
+        void finishRecruitment(game).catch(error => logDiscordFailure(game, 'recruitment-timer', error));
+    }, RECRUITMENT_DURATION_MS);
+    game.timers.add(game.recruitmentTimer);
+    return true;
+}
+
+function parseParts(parts) {
+    const input = (Array.isArray(parts) ? parts : [parts]).filter(part => typeof part === 'string');
+    const tokens = input.flatMap(part => part.split(':')).filter(Boolean);
+    if (tokens[0]?.startsWith('mystery_bomb_')) {
+        tokens[0] = tokens[0].slice('mystery_bomb_'.length);
+    }
+    while (tokens[0] === 'mystery' || tokens[0] === 'bomb') tokens.shift();
+    return { action: tokens[0], gameId: tokens[1], messageToken: Number(tokens[2]) };
+}
+
+async function handleJoin(interaction, game) {
+    const userId = interaction.user?.id;
+    let rejection = null;
+    const inspect = () => {
+        if (
+            game.ended
+            || game.state !== 'recruiting'
+            || game.recruitmentClosing
+            || interaction.channelId !== game.channelId
+            || (interaction.guildId || interaction.guild?.id) !== game.guildId
+        ) return EXPIRED_MESSAGE;
+        if (
+            game.participantIds.includes(userId)
+            || game.pendingJoinReservations?.has(userId)
+        ) return DUPLICATE_MESSAGE;
+        if (game.participantIds.length >= MAX_PARTICIPANTS) return FULL_MESSAGE;
+        return null;
+    };
+    await gameManager.runExclusive(game, () => { rejection = inspect(); });
+    if (rejection) {
+        await safeEphemeralReply(interaction, rejection, game);
+        return false;
+    }
+
+    const member = await safeFetchMember(game, userId);
+    if (!isValidHumanMember(member)) {
+        await safeEphemeralReply(
+            interaction,
+            isActivelyTimedOut(member) ? TIMEOUT_BLOCKED_MESSAGE : INVALID_MEMBER_MESSAGE,
+            game
+        );
+        return false;
+    }
+
+    let reservation = null;
+    await gameManager.runExclusive(game, () => {
+        rejection = inspect();
+        if (rejection) return;
+        if (!isValidHumanMember(member)) {
+            rejection = isActivelyTimedOut(member) ? TIMEOUT_BLOCKED_MESSAGE : INVALID_MEMBER_MESSAGE;
+            return;
+        }
+        const owner = gameManager.getPlayerGame(game.guildId, userId);
+        if (owner && owner !== game) {
+            rejection = PLAYER_BUSY_MESSAGE;
+            return;
+        }
+        if (!gameManager.addPlayer(game, userId)) {
+            rejection = PLAYER_BUSY_MESSAGE;
+            return;
+        }
+        game.memberById?.set(userId, member);
+        game.pendingJoinReservations ||= new Map();
+        game.joinReservationVersion = (game.joinReservationVersion || 0) + 1;
+        reservation = { userId, token: game.joinReservationVersion };
+        game.pendingJoinReservations.set(userId, reservation);
+    });
+    if (!reservation) {
+        await safeEphemeralReply(interaction, rejection || EXPIRED_MESSAGE, game);
+        return false;
+    }
+
+    let joined = false;
+    let rollbackFailed = false;
+    let shouldStart = false;
+    let finalized = false;
+    const finalizeReservation = async panelUpdated => {
+        await gameManager.runExclusive(game, () => {
+            const current = game.pendingJoinReservations?.get(userId);
+            if (current?.token !== reservation.token) return;
+            game.pendingJoinReservations.delete(userId);
+            joined = Boolean(
+                panelUpdated
+                && !game.ended
+                && game.state === 'recruiting'
+                && !game.recruitmentClosing
+                && game.participantIds.includes(userId)
+            );
+            if (!joined && game.participantIds.includes(userId)) {
+                gameManager.removePlayer(game, userId);
+            }
+            if (!joined) game.memberById?.delete(userId);
+            rollbackFailed = !joined && (
+                gameManager.getPlayerGame(game.guildId, userId) === game
+                || (!game.ended && game.participantIds.includes(userId))
+            );
+            game.recruitmentPayload = recruitmentPayload(game);
+            shouldStart = !game.ended
+                && game.state === 'recruiting'
+                && !game.recruitmentClosing
+                && game.pendingJoinReservations.size === 0
+                && (game.recruitmentStartRequested || game.participantIds.length === MAX_PARTICIPANTS);
+            finalized = true;
+        });
+    };
+
+    const panelResult = await queuePanelWrite(game, async () => {
+        let payload = null;
+        await gameManager.runExclusive(game, () => {
+            const current = game.pendingJoinReservations?.get(userId);
+            if (
+                current?.token !== reservation.token
+                || game.ended
+                || game.state !== 'recruiting'
+                || game.recruitmentClosing
+                || !game.participantIds.includes(userId)
+            ) return;
+            const visibleCount = game.participantIds.filter(participantId => (
+                participantId === userId
+                || !game.pendingJoinReservations.has(participantId)
+            )).length;
+            payload = recruitmentPayload(
+                game,
+                false,
+                recruitmentDescription(game, visibleCount)
+            );
+        });
+        const panelUpdated = payload
+            ? await safeEdit(game.recruitmentMessage, payload, game, 'join-count-panel')
+            : false;
+        await finalizeReservation(panelUpdated);
+        return panelUpdated;
+    });
+    if (!finalized) await finalizeReservation(false);
+    if (rollbackFailed) await abortAfterCriticalPanelFailure(game);
+
+    await safeEphemeralReply(interaction, joined ? JOINED_MESSAGE : EXPIRED_MESSAGE, game);
+    if (shouldStart) await finishRecruitment(game);
+    return Boolean(panelResult && joined);
+}
+
+async function handlePassButton(interaction, game, messageToken) {
+    const actorId = interaction.user?.id;
+    const currentTime = nowFor(game);
+    if (currentTime >= game.explodeAt) {
+        await explodeBomb(game, currentTime);
+        await safeEphemeralReply(interaction, EXPIRED_MESSAGE, game);
+        return false;
+    }
+
+    let rejection = null;
+    let participantIds = [];
+    await gameManager.runExclusive(game, () => {
+        if (game.ended || game.state !== 'active') rejection = EXPIRED_MESSAGE;
+        else if (game.messageToken !== messageToken) rejection = EXPIRED_MESSAGE;
+        else if (game.currentHolderId !== actorId) rejection = NOT_HOLDER_MESSAGE;
+        else if (currentTime - game.holderSince < 1_000) rejection = TOO_FAST_MESSAGE;
+        else participantIds = [...game.participantIds];
+    });
+    if (rejection) {
+        await safeEphemeralReply(interaction, rejection, game);
+        return false;
+    }
+
+    const options = [];
+    for (const userId of participantIds) {
+        if (userId === actorId) continue;
+        const member = await safeFetchMember(game, userId);
+        if (!isValidHumanMember(member)) continue;
+        const label = member.displayName || member.user.globalName || member.user.username || userId;
+        options.push({ label: String(label).slice(0, 100), value: userId });
+    }
+
+    await gameManager.runExclusive(game, () => {
+        const freshTime = nowFor(game);
+        if (game.ended || game.state !== 'active' || freshTime >= game.explodeAt) rejection = EXPIRED_MESSAGE;
+        else if (game.messageToken !== messageToken) rejection = EXPIRED_MESSAGE;
+        else if (game.currentHolderId !== actorId) rejection = NOT_HOLDER_MESSAGE;
+        else if (freshTime - game.holderSince < 1_000) rejection = TOO_FAST_MESSAGE;
+    });
+    if (rejection) {
+        if (nowFor(game) >= game.explodeAt) await explodeBomb(game, nowFor(game));
+        await safeEphemeralReply(interaction, rejection, game);
+        return false;
+    }
+    if (options.length === 0) {
+        await safeEphemeralReply(interaction, TARGET_INVALID_MESSAGE, game);
+        return false;
+    }
+
+    const select = new StringSelectMenuBuilder()
+        .setCustomId(`mystery_bomb_target:${game.id}:${messageToken}`)
+        .setPlaceholder('选择一名参与者')
+        .addOptions(options);
+    await safeEphemeralReply(
+        interaction,
+        '💣 **你打算把这个祸害送给谁？**',
+        game,
+        [new ActionRowBuilder().addComponents(select)]
+    );
+    return true;
+}
+
+async function submitBombTarget(game, input) {
+    if (!game || game.type !== 'bomb') return { ok: false, reason: 'expired' };
+    const targetMember = await safeFetchMember(game, input.targetId);
+    let result = { ok: false, reason: 'expired' };
+    let passCommit = null;
+    let explosionClaimed = false;
+
+    await gameManager.runExclusive(game, () => {
+        const currentTime = input.now ?? nowFor(game);
+        if (game.ended || game.state !== 'active') return;
+        if (currentTime >= game.explodeAt) {
+            game.state = 'exploding';
+            game.finalHolderId = game.currentHolderId;
+            game.explosionClaimedAt = currentTime;
+            explosionClaimed = true;
+            result = { ok: false, reason: 'exploded' };
+            return;
+        }
+        if (game.currentHolderId !== input.actorId) {
+            result = { ok: false, reason: 'holder' };
+            return;
+        }
+        if (game.messageToken !== input.messageToken) {
+            result = { ok: false, reason: 'stale' };
+            return;
+        }
+        if (
+            input.targetId === input.actorId
+            || !game.participantIds.includes(input.targetId)
+            || !isValidHumanMember(targetMember)
+        ) {
+            result = { ok: false, reason: 'target' };
+            return;
+        }
+
+        const oldMessage = game.currentMessage;
+        const oldToken = game.messageToken;
+        const randomValue = randomFor(game);
+        game.currentHolderId = input.targetId;
+        game.holderSince = currentTime;
+        game.passCount += 1;
+        game.messageToken += 1;
+        passCommit = {
+            fromId: input.actorId,
+            toId: input.targetId,
+            oldMessage,
+            oldToken,
+            newToken: game.messageToken,
+            passCount: game.passCount,
+            randomValue,
+        };
+        result = { ok: true };
+    });
+
+    if (explosionClaimed) {
+        await finishExplosion(game);
+        return result;
+    }
+    if (!passCommit) return result;
+
+    const deliveredMessage = await queuePublicWrite(game, async () => {
+        if (
+            game.ended
+            || game.state !== 'active'
+            || game.messageToken !== passCommit.newToken
+            || game.currentHolderId !== passCommit.toId
+        ) return PANEL_SKIPPED;
+        const oldMessage = game.messageByToken?.get(passCommit.oldToken) || passCommit.oldMessage;
+        await disableBombMessage(game, oldMessage, passCommit.oldToken);
+        const payload = {
+            embeds: [makeEmbed(passDescription(
+                passCommit.fromId,
+                passCommit.toId,
+                passCommit.passCount,
+                passCommit.randomValue
+            ))],
+            components: [passRow(game.id, passCommit.newToken)],
+        };
+        const message = await safeSend(game, payload, 'pass-message');
+        if (message) {
+            message.bombMessageToken = passCommit.newToken;
+            game.currentMessage = message;
+            game.bombMessages ||= new Set();
+            game.bombMessages.add(message);
+            game.messageByToken ||= new Map();
+            game.messageByToken.set(passCommit.newToken, message);
+        }
+        return message;
+    });
+    if (deliveredMessage === null) {
+        await abortAfterCriticalPanelFailure(game);
+        return { ok: false, reason: 'delivery' };
+    }
+    return result;
+}
+
+async function handleTargetSelect(interaction, game, messageToken) {
+    const result = await submitBombTarget(game, {
+        actorId: interaction.user?.id,
+        targetId: interaction.values?.[0],
+        messageToken,
+    });
+    if (result.ok) {
+        await safeEphemeralReply(interaction, '💣 **炸弹已经成功转交。**', game);
+        return true;
+    }
+    const content = result.reason === 'target'
+        ? TARGET_INVALID_MESSAGE
+        : result.reason === 'holder'
+            ? NOT_HOLDER_MESSAGE
+            : EXPIRED_MESSAGE;
+    await safeEphemeralReply(interaction, content, game);
+    return false;
+}
+
+async function handleBombInteraction(interaction, parts) {
+    const parsed = parseParts(parts);
+    const game = parsed.gameId && gameManager.getGame(parsed.gameId);
+    if (!await deferEphemeralComponent(interaction, game)) return false;
+    if (!game || game.type !== 'bomb') {
+        await safeEphemeralReply(interaction, EXPIRED_MESSAGE, game);
+        return false;
+    }
+    if (parsed.action === 'join') return handleJoin(interaction, game);
+    if (parsed.action === 'pass') return handlePassButton(interaction, game, parsed.messageToken);
+    if (parsed.action === 'target') return handleTargetSelect(interaction, game, parsed.messageToken);
+    await safeEphemeralReply(interaction, EXPIRED_MESSAGE, game);
+    return false;
+}
+
+async function handleBombMemberInvalidated(game, userId, reason) {
+    if (!game || game.type !== 'bomb') return false;
+    let removed = false;
+    let outcome = null;
+    let reassignment = null;
+    let explosionClaimed = false;
+
+    await gameManager.runExclusive(game, () => {
+        if (
+            game.ended
+            || (game.state !== 'recruiting' && game.state !== 'active')
+            || !game.participantIds.includes(userId)
+        ) return;
+        const currentTime = nowFor(game);
+        if (game.state === 'active' && currentTime >= game.explodeAt) {
+            game.state = 'exploding';
+            game.finalHolderId = game.currentHolderId;
+            game.explosionClaimedAt = currentTime;
+            explosionClaimed = true;
+            return;
+        }
+
+        const wasHolder = game.currentHolderId === userId;
+        removed = gameManager.removePlayer(game, userId);
+        game.memberById?.delete(userId);
+        if (!removed) return;
+        if (game.state === 'recruiting') {
+            outcome = 'recruiting';
+            return;
+        }
+        if (game.state !== 'active') return;
+        if (wasHolder) {
+            for (const participantId of [...game.participantIds]) {
+                const knownMember = game.memberById?.get(participantId)
+                    || game.guild?.members?.cache?.get(participantId);
+                if (knownMember && !isValidHumanMember(knownMember)) {
+                    gameManager.removePlayer(game, participantId);
+                    game.memberById?.delete(participantId);
+                }
+            }
+        }
+        if (game.participantIds.length < MIN_PARTICIPANTS) {
+            game.state = 'cancelling';
+            outcome = 'cancel';
+            return;
+        }
+        if (!wasHolder) {
+            outcome = 'continue';
+            return;
+        }
+
+        const oldMessage = game.currentMessage;
+        const oldToken = game.messageToken;
+        const newHolderId = game.participantIds[randomIndex(game.participantIds.length, randomFor(game))];
+        game.currentHolderId = newHolderId;
+        game.holderSince = currentTime;
+        game.messageToken += 1;
+        reassignment = {
+            newHolderId,
+            oldMessage,
+            oldToken,
+            newToken: game.messageToken,
+        };
+        outcome = 'reassign';
+    });
+
+    if (explosionClaimed) {
+        await finishExplosion(game);
+        return false;
+    }
+    if (!removed) return false;
+    if (outcome === 'recruiting') {
+        await queuePanelWrite(game, () => {
+            if (game.state !== 'recruiting') return false;
+            game.recruitmentPayload = recruitmentPayload(game);
+            return safeEdit(game.recruitmentMessage, game.recruitmentPayload, game, 'member-left-recruitment');
+        });
+    } else if (outcome === 'cancel') {
+        await cancelForTooFew(game, false);
+    } else if (outcome === 'reassign') {
+        const deliveredMessage = await queuePublicWrite(game, async () => {
+            if (
+                game.ended
+                || game.state !== 'active'
+                || game.messageToken !== reassignment.newToken
+                || game.currentHolderId !== reassignment.newHolderId
+            ) return PANEL_SKIPPED;
+            const oldMessage = game.messageByToken?.get(reassignment.oldToken) || reassignment.oldMessage;
+            await disableBombMessage(game, oldMessage, reassignment.oldToken);
+            const payload = {
+                embeds: [makeEmbed(reassignmentDescription(userId, reassignment.newHolderId, reason))],
+                components: [passRow(game.id, reassignment.newToken)],
+            };
+            const message = await safeSend(game, payload, 'member-invalidated-reassignment');
+            if (message) {
+                message.bombMessageToken = reassignment.newToken;
+                game.currentMessage = message;
+                game.bombMessages ||= new Set();
+                game.bombMessages.add(message);
+                game.messageByToken ||= new Map();
+                game.messageByToken.set(reassignment.newToken, message);
+            }
+            return message;
+        });
+        if (deliveredMessage === null) {
+            await abortAfterCriticalPanelFailure(game);
+        }
+    }
+    return true;
+}
+
+module.exports = {
+    startBomb,
+    handleBombInteraction,
+    randomExplosionDelayMs,
+    submitBombTarget,
+    handleBombMemberInvalidated,
+};

--- a/src/modules/mystery/services/duelGame.js
+++ b/src/modules/mystery/services/duelGame.js
@@ -1,0 +1,1012 @@
+const { randomUUID } = require('node:crypto');
+const {
+    ActionRowBuilder,
+    ButtonBuilder,
+    ButtonStyle,
+    EmbedBuilder,
+    MessageFlags,
+} = require('discord.js');
+const gameManager = require('./mysteryGameManager');
+
+const INVITATION_DURATION_MS = 60_000;
+const ROUND_DURATION_MS = 30_000;
+const MAX_DUEL_ROUNDS = 7;
+const DUEL_TIMEOUT_DURATION_MS = 3 * 60_000;
+const DUEL_TIMEOUT_REASON = '神秘指令：死斗';
+
+const PLAYER_BUSY_MESSAGE = '🚫 **一心不能二用。**\n你现在已经在一场神秘游戏里，先把那边活着玩完再说。';
+const CHANNEL_BUSY_MESSAGE = '🎮 **这里已经有一场游戏在进行了。**\n等当前游戏结束后再开新的吧。';
+const INVALID_OPPONENT_MESSAGE = '⚔️ **这个对手现在无法参加死斗。**\n换个人再试试吧。';
+const GENERIC_FAILURE_MESSAGE = '❌ 处理神秘指令时出现错误，请稍后重试。';
+const WRONG_INVITEE_MESSAGE = '🚫 **这不是发给你的邀请。**';
+const TIMEOUT_BLOCKED_MESSAGE = '⚔️ **你现在无法参加死斗。**\n你当前还在禁言，暂时无法参加。';
+const INVALID_INITIATOR_MESSAGE = '⚔️ **你现在无法参加死斗。**';
+const EXPIRED_MESSAGE = '⌛ **这场死斗已经结束或失效了。**';
+const SELF_ACCEPT_MESSAGE = '⚔️ **不能接受自己发起的死斗。**';
+const DUPLICATE_CHOICE_MESSAGE = '✋ **本轮已经出过拳了。**\n选择不能修改。';
+const INVALID_CHOICE_MESSAGE = '⚠️ **这个出拳无效。**';
+const CHOICE_RECORDED_MESSAGE = '✅ **出拳已记录。**\n等待对手完成选择。';
+const BOTH_TIMEOUT_DESCRIPTION = '💤 **两个人都没出拳。**\n\n看来这场死斗的杀气也就到这里了。\n\n**本场死斗自动取消。**';
+const INVALIDATED_DESCRIPTION = '⚔️ **死斗中止。**\n\n由于其中一名玩家已无法继续参与，本场死斗自动取消。';
+const ROUND_LIMIT_DESCRIPTION = [
+    '⌛ **死斗已失效**',
+    '',
+    '双方鏖战 **7 轮**，仍然没有分出胜负。',
+    '',
+    '本场死斗到此为止，双方均不受处罚。',
+].join('\n');
+const SHIELD_LINE = '🛡️ **但禁言被神秘力量阻挡，未能生效。**';
+
+const CHOICES = {
+    rock: { label: '✊ 石头', display: '✊ 石头', style: ButtonStyle.Secondary },
+    scissors: { label: '✌️ 剪刀', display: '✌️ 剪刀', style: ButtonStyle.Secondary },
+    paper: { label: '✋ 布', display: '✋ 布', style: ButtonStyle.Secondary },
+};
+
+function logDiscordFailure(game, action, error, userId = 'system') {
+    console.error(
+        `[MysteryDuel] Discord API 失败 (guild=${game?.guildId || 'unknown'}, game=${game?.id || 'unknown'}, user=${userId}, action=${action}):`,
+        error
+    );
+}
+
+function makeEmbed(description) {
+    return new EmbedBuilder().setDescription(description);
+}
+
+function isActivelyTimedOut(member, now = Date.now()) {
+    return Number(member?.communicationDisabledUntilTimestamp) > now;
+}
+
+function isValidHumanMember(member) {
+    return Boolean(member?.id && member.user && !member.user.bot && !isActivelyTimedOut(member));
+}
+
+function isCurrentGuildMember(game, member, userId = member?.id) {
+    if (!isValidHumanMember(member) || member.id !== userId) return false;
+    const memberGuildId = member.guild?.id || member.guildId;
+    if (!memberGuildId || memberGuildId !== game.guildId) return false;
+    return game.guild?.members?.cache?.get(userId) === member;
+}
+
+async function safeFetchMember(game, userId) {
+    try {
+        return await game.guild?.members?.fetch(userId) || null;
+    } catch (error) {
+        logDiscordFailure(game, 'fetch-member', error, userId);
+        return null;
+    }
+}
+
+async function deferEphemeralComponent(interaction, game) {
+    if (interaction.deferred || interaction.replied || typeof interaction.deferReply !== 'function') {
+        return true;
+    }
+    try {
+        await interaction.deferReply({ flags: MessageFlags.Ephemeral });
+        return true;
+    } catch (error) {
+        logDiscordFailure(game, 'defer-component-reply', error, interaction.user?.id);
+        return false;
+    }
+}
+
+async function sendPrivate(interaction, payload, game) {
+    try {
+        if (interaction.deferred && !interaction.replied && typeof interaction.editReply === 'function') {
+            await interaction.editReply(payload);
+        } else if (interaction.replied && typeof interaction.followUp === 'function') {
+            await interaction.followUp({ ...payload, flags: MessageFlags.Ephemeral });
+        } else if (!interaction.replied && typeof interaction.reply === 'function') {
+            await interaction.reply({ ...payload, flags: MessageFlags.Ephemeral });
+        } else {
+            return false;
+        }
+        return true;
+    } catch (error) {
+        logDiscordFailure(game, 'private-reply', error, interaction.user?.id);
+        return false;
+    }
+}
+
+async function safeEphemeralReply(interaction, content, game) {
+    return sendPrivate(interaction, { content }, game);
+}
+
+async function deferPublicStart(interaction, game) {
+    if (interaction.deferred || interaction.replied || typeof interaction.deferReply !== 'function') {
+        return false;
+    }
+    try {
+        await interaction.deferReply();
+        return true;
+    } catch (error) {
+        logDiscordFailure(game, 'defer-start-reply', error, interaction.user?.id);
+        return false;
+    }
+}
+
+async function rejectDeferredStart(interaction, content, game) {
+    try {
+        await interaction.deleteReply?.();
+    } catch (error) {
+        logDiscordFailure(game, 'delete-start-reply', error, interaction.user?.id);
+    }
+    try {
+        if (typeof interaction.followUp !== 'function') return false;
+        await interaction.followUp({ content, flags: MessageFlags.Ephemeral });
+        return true;
+    } catch (error) {
+        logDiscordFailure(game, 'reject-start-reply', error, interaction.user?.id);
+        return false;
+    }
+}
+
+async function safeEdit(message, payload, game, action) {
+    if (typeof message?.edit !== 'function') return false;
+    try {
+        await message.edit(payload);
+        return true;
+    } catch (error) {
+        logDiscordFailure(game, action, error);
+        return false;
+    }
+}
+
+async function safeSend(game, payload, action) {
+    try {
+        return await game.channel?.send(payload) || null;
+    } catch (error) {
+        logDiscordFailure(game, action, error);
+        return null;
+    }
+}
+
+function queuePublicWrite(game, operation) {
+    const previous = game.publicWriteQueue || Promise.resolve();
+    const queued = previous
+        .catch(error => logDiscordFailure(game, 'public-write-queue', error))
+        .then(operation)
+        .catch(error => {
+            logDiscordFailure(game, 'public-write-queue', error);
+            return null;
+        });
+    game.publicWriteQueue = queued;
+    return queued;
+}
+
+function acceptRow(gameId, disabled = false) {
+    return new ActionRowBuilder().addComponents(
+        new ButtonBuilder()
+            .setCustomId(`mystery_duel_accept:${gameId}`)
+            .setLabel('⚔️ 接受死斗')
+            .setStyle(ButtonStyle.Danger)
+            .setDisabled(disabled)
+    );
+}
+
+function choiceRow(gameId, roundId) {
+    return new ActionRowBuilder().addComponents(
+        ...Object.entries(CHOICES).map(([choice, details]) => (
+            new ButtonBuilder()
+                .setCustomId(`mystery_duel_choice:${gameId}:${roundId}:${choice}`)
+                .setLabel(details.label)
+                .setStyle(details.style)
+        ))
+    );
+}
+
+function invitationDescription(initiatorId, requestedOpponentId) {
+    if (requestedOpponentId) {
+        return [
+            '⚔️ **死斗邀请已发出**',
+            '',
+            `<@${initiatorId}> 向 <@${requestedOpponentId}> 发起了一场死斗。`,
+            '',
+            '**游戏规则**',
+            '- 双人游戏',
+            '- 石头剪刀布',
+            '- 三局两胜',
+            '- 最多进行 **7 轮**；仍未分出胜负则自动失效',
+            '- 输家将被 **禁言 3 分钟**',
+            '',
+            `<@${requestedOpponentId}>，敢接吗？`,
+        ].join('\n');
+    }
+    return [
+        '⚔️ **有人发起了一场死斗**',
+        '',
+        `<@${initiatorId}> 正在寻找一名对手。`,
+        '',
+        '**游戏规则**',
+        '- 双人游戏',
+        '- 石头剪刀布',
+        '- 三局两胜',
+        '- 最多进行 **7 轮**；仍未分出胜负则自动失效',
+        '- 输家将被 **禁言 3 分钟**',
+        '',
+        '谁敢来？',
+    ].join('\n');
+}
+
+function invitationPayload(game, disabled = false, description) {
+    return {
+        embeds: [makeEmbed(description || invitationDescription(game.initiatorId, game.requestedOpponentId))],
+        components: [acceptRow(game.id, disabled)],
+    };
+}
+
+function roundLabel(number) {
+    const labels = ['第一轮', '第二轮', '第三轮', '第四轮', '第五轮', '第六轮', '第七轮'];
+    return labels[number - 1] || `第 ${number} 轮`;
+}
+
+function choicePayload(game, round) {
+    return {
+        content: `⚔️ **${roundLabel(round.number)}：请选择出拳**\n选择以后不能修改，你有 **30 秒**。`,
+        components: [choiceRow(game.id, round.id)],
+    };
+}
+
+function scoreLines(game, scores) {
+    return [
+        '**当前比分**',
+        `<@${game.initiatorId}> **${scores[game.initiatorId]} : ${scores[game.opponentId]}** <@${game.opponentId}>`,
+    ];
+}
+
+function normalRoundDescription(game, snapshot) {
+    const a = game.initiatorId;
+    const b = game.opponentId;
+    if (snapshot.outcome === 'tie') {
+        return [
+            '⚔️ **本轮平局**',
+            '',
+            `<@${a}>：${CHOICES[snapshot.choices[a]].display}`,
+            `<@${b}>：${CHOICES[snapshot.choices[b]].display}`,
+            '',
+            '双方不得分。',
+            '',
+            ...scoreLines(game, snapshot.scores),
+        ].join('\n');
+    }
+    if (snapshot.outcome === 'timeout') {
+        return [
+            `⚔️ **${roundLabel(snapshot.number)}结果**`,
+            '',
+            `<@${snapshot.winnerId}> 已出拳`,
+            `<@${snapshot.loserId}> 超时未出拳`,
+            '',
+            `**<@${snapshot.winnerId}> 获胜！**`,
+            '',
+            ...scoreLines(game, snapshot.scores),
+        ].join('\n');
+    }
+    return [
+        `⚔️ **${roundLabel(snapshot.number)}结果**`,
+        '',
+        `<@${a}>：${CHOICES[snapshot.choices[a]].display}`,
+        `<@${b}>：${CHOICES[snapshot.choices[b]].display}`,
+        '',
+        `**<@${snapshot.winnerId}> 获胜！**`,
+        '',
+        ...scoreLines(game, snapshot.scores),
+    ].join('\n');
+}
+
+function finalDescription(game, snapshot, timeoutFailed) {
+    const winnerScore = snapshot.scores[snapshot.winnerId];
+    const loserScore = snapshot.scores[snapshot.loserId];
+    const lines = [
+        '🏆 **死斗结束**',
+        '',
+        `**胜者：<@${snapshot.winnerId}>**`,
+        `**败者：<@${snapshot.loserId}>**`,
+        '',
+        `最终比分：**${winnerScore} : ${loserScore}**`,
+        '',
+        `<@${snapshot.loserId}> 将接受 **禁言 3 分钟**。`,
+    ];
+    if (timeoutFailed) lines.push('', SHIELD_LINE);
+    return lines.join('\n');
+}
+
+function resolveChoices(a, b) {
+    if (a === b) return 0;
+    if (
+        (a === 'rock' && b === 'scissors')
+        || (a === 'scissors' && b === 'paper')
+        || (a === 'paper' && b === 'rock')
+    ) return 1;
+    return -1;
+}
+
+function clearTimer(game, timer) {
+    if (!timer) return;
+    clearTimeout(timer);
+    game.timers?.delete(timer);
+}
+
+async function disableInvitation(game) {
+    if (game.componentsDisabled) return true;
+    const disabled = await safeEdit(
+        game.inviteMessage,
+        { components: [acceptRow(game.id, true)] },
+        game,
+        'disable-invitation'
+    );
+    if (disabled) game.componentsDisabled = true;
+    return disabled;
+}
+
+async function disableInvitationWithRetry(game) {
+    if (await disableInvitation(game)) return true;
+    return disableInvitation(game);
+}
+
+async function cleanupDuelGame(game) {
+    if (!game || game.cleanupStarted) return game?.cleanupPromise;
+    game.cleanupStarted = true;
+    game.cleanupPromise = (async () => {
+        await disableInvitation(game);
+        await gameManager.cleanupGame(game);
+    })().catch(error => {
+        logDiscordFailure(game, 'cleanup', error);
+    });
+    return game.cleanupPromise;
+}
+
+function createRound(game) {
+    game.roundNumber = (game.roundNumber || 0) + 1;
+    return {
+        id: randomUUID().replaceAll('-', '').slice(0, 12),
+        number: game.roundNumber,
+        choices: new Map(),
+        resolved: false,
+        timer: null,
+    };
+}
+
+async function deliverRoundPanels(game, round) {
+    if (game.ended || game.state !== 'round' || game.round !== round) return null;
+    const payload = choicePayload(game, round);
+    const [initiatorSent, opponentSent] = await Promise.all([
+        sendPrivate(game.originInteraction, payload, game),
+        sendPrivate(game.opponentInteraction, payload, game),
+    ]);
+    if (!initiatorSent || !opponentSent) {
+        await cleanupDuelGame(game);
+        return false;
+    }
+
+    let armed = false;
+    await gameManager.runExclusive(game, () => {
+        if (game.ended || game.state !== 'round' || game.round !== round || round.resolved) return;
+        round.timer = setTimeout(() => {
+            return handleRoundTimeout(game, round.id).catch(error => {
+                logDiscordFailure(game, 'round-timer', error);
+                return cleanupDuelGame(game);
+            });
+        }, ROUND_DURATION_MS);
+        round.timer.unref?.();
+        game.timers.add(round.timer);
+        armed = true;
+    });
+    return armed ? true : null;
+}
+
+function claimRoundResolution(game, round, mode) {
+    if (game.ended || game.state !== 'round' || game.round !== round || round.resolved) return null;
+    const playerIds = [game.initiatorId, game.opponentId];
+    const choiceIds = playerIds.filter(userId => round.choices.has(userId));
+    if (mode === 'choices' && choiceIds.length !== 2) return null;
+
+    round.resolved = true;
+    clearTimer(game, round.timer);
+    round.timer = null;
+
+    if (choiceIds.length === 0) {
+        game.state = 'ended';
+        return { outcome: 'cancel', roundId: round.id, number: round.number };
+    }
+
+    let winnerId;
+    let loserId;
+    let outcome;
+    if (choiceIds.length === 1) {
+        winnerId = choiceIds[0];
+        loserId = playerIds.find(userId => userId !== winnerId);
+        outcome = 'timeout';
+    } else {
+        const result = resolveChoices(
+            round.choices.get(game.initiatorId),
+            round.choices.get(game.opponentId)
+        );
+        if (result === 0) {
+            outcome = 'tie';
+        } else {
+            winnerId = result === 1 ? game.initiatorId : game.opponentId;
+            loserId = result === 1 ? game.opponentId : game.initiatorId;
+            outcome = 'choice';
+        }
+    }
+
+    if (winnerId) game.scores[winnerId] += 1;
+    const final = Boolean(winnerId && game.scores[winnerId] >= 2);
+    let effectToken = null;
+    if (final) {
+        effectToken = randomUUID().replaceAll('-', '').slice(0, 16);
+        game.pendingFinal = { roundId: round.id, effectToken };
+    }
+    return {
+        outcome,
+        final,
+        roundId: round.id,
+        number: round.number,
+        winnerId,
+        loserId,
+        choices: Object.fromEntries(round.choices),
+        scores: { ...game.scores },
+        effectToken,
+    };
+}
+
+async function applyLoserTimeout(game, snapshot, loser) {
+    if (!loser?.moderatable || typeof loser.timeout !== 'function') return false;
+    try {
+        await loser.timeout(DUEL_TIMEOUT_DURATION_MS, DUEL_TIMEOUT_REASON);
+        return true;
+    } catch (error) {
+        logDiscordFailure(game, 'timeout-loser', error, snapshot.loserId);
+        return false;
+    }
+}
+
+async function appendTimeoutFailure(game, snapshot, finalMessage) {
+    const payload = { embeds: [makeEmbed(finalDescription(game, snapshot, true))] };
+    if (await safeEdit(finalMessage, payload, game, 'append-timeout-shield')) return true;
+    return Boolean(await queuePublicWrite(game, () => safeSend(
+        game,
+        { embeds: [makeEmbed(SHIELD_LINE)] },
+        'supplement-timeout-shield'
+    )));
+}
+
+async function publishRoundResolution(game, snapshot) {
+    if (!snapshot) return false;
+    if (snapshot.outcome === 'cancel') {
+        await queuePublicWrite(game, () => safeSend(
+            game,
+            { embeds: [makeEmbed(BOTH_TIMEOUT_DESCRIPTION)] },
+            'both-timeout-cancel'
+        ));
+        await cleanupDuelGame(game);
+        return true;
+    }
+
+    const roundMessage = await queuePublicWrite(game, () => {
+        if (
+            game.ended
+            || game.round?.id !== snapshot.roundId
+            || game.state !== 'round'
+        ) return false;
+        return safeSend(
+            game,
+            { embeds: [makeEmbed(normalRoundDescription(game, snapshot))] },
+            'round-result'
+        );
+    });
+    if (roundMessage === false) return false;
+    if (!roundMessage) {
+        await cleanupDuelGame(game);
+        return false;
+    }
+
+    if (snapshot.final) {
+        const finalMembers = new Map();
+        const fetchedMembers = await Promise.all([
+            safeFetchMember(game, game.initiatorId),
+            safeFetchMember(game, game.opponentId),
+        ]);
+        finalMembers.set(game.initiatorId, fetchedMembers[0]);
+        finalMembers.set(game.opponentId, fetchedMembers[1]);
+
+        let finalDecision = null;
+        await gameManager.runExclusive(game, () => {
+            if (
+                game.ended
+                || game.state !== 'round'
+                || game.round?.id !== snapshot.roundId
+                || game.pendingFinal?.roundId !== snapshot.roundId
+                || game.pendingFinal?.effectToken !== snapshot.effectToken
+                || game.finalEffect
+            ) return;
+
+            const participantsCurrent = game.participantIds.every(userId => (
+                isCurrentGuildMember(game, finalMembers.get(userId), userId)
+            ));
+            if (!participantsCurrent) {
+                game.state = 'ended';
+                game.pendingFinal = null;
+                game.finalEffect = { token: snapshot.effectToken, phase: 'cancelled' };
+                finalDecision = 'cancel';
+                return;
+            }
+
+            game.finalEffect = { token: snapshot.effectToken, phase: 'publishing-result' };
+            finalDecision = 'publish';
+        });
+        if (!finalDecision) return false;
+        if (finalDecision === 'cancel') {
+            await queuePublicWrite(game, () => safeSend(
+                game,
+                { embeds: [makeEmbed(INVALIDATED_DESCRIPTION)] },
+                'final-member-invalidated-cancel'
+            ));
+            await cleanupDuelGame(game);
+            return false;
+        }
+
+        const finalMessage = await queuePublicWrite(game, () => {
+            if (
+                game.ended
+                || game.state !== 'round'
+                || game.round?.id !== snapshot.roundId
+                || game.pendingFinal?.roundId !== snapshot.roundId
+                || game.pendingFinal?.effectToken !== snapshot.effectToken
+                || game.finalEffect?.token !== snapshot.effectToken
+                || game.finalEffect.phase !== 'publishing-result'
+            ) return false;
+            return safeSend(
+                game,
+                { embeds: [makeEmbed(finalDescription(game, snapshot, false))] },
+                'final-result'
+            );
+        });
+        if (finalMessage === false) return false;
+        if (!finalMessage) {
+            await gameManager.runExclusive(game, () => {
+                if (
+                    game.ended
+                    || game.state !== 'round'
+                    || game.pendingFinal?.effectToken !== snapshot.effectToken
+                    || game.finalEffect?.token !== snapshot.effectToken
+                    || game.finalEffect.phase !== 'publishing-result'
+                ) return;
+                game.state = 'ended';
+                game.pendingFinal = null;
+                game.finalEffect.phase = 'publish-failed';
+            });
+            await cleanupDuelGame(game);
+            return false;
+        }
+
+        let applyTimeout = false;
+        await gameManager.runExclusive(game, () => {
+            if (
+                game.ended
+                || game.state !== 'round'
+                || game.round?.id !== snapshot.roundId
+                || game.pendingFinal?.roundId !== snapshot.roundId
+                || game.pendingFinal?.effectToken !== snapshot.effectToken
+                || game.finalEffect?.token !== snapshot.effectToken
+                || game.finalEffect.phase !== 'publishing-result'
+            ) return;
+            game.state = 'ended';
+            game.pendingFinal = null;
+            game.finalEffect.phase = 'applying-timeout';
+            applyTimeout = true;
+        });
+        if (!applyTimeout) {
+            await cleanupDuelGame(game);
+            return false;
+        }
+
+        const timeoutApplied = await applyLoserTimeout(
+            game,
+            snapshot,
+            finalMembers.get(snapshot.loserId)
+        );
+        if (game.finalEffect?.token === snapshot.effectToken) {
+            game.finalEffect.phase = timeoutApplied ? 'complete' : 'supplementing-result';
+        }
+        if (!timeoutApplied) await appendTimeoutFailure(game, snapshot, finalMessage);
+        if (game.finalEffect?.token === snapshot.effectToken) game.finalEffect.phase = 'complete';
+        await cleanupDuelGame(game);
+        return true;
+    }
+
+    if (snapshot.number >= MAX_DUEL_ROUNDS) {
+        let ownsRoundLimit = false;
+        await gameManager.runExclusive(game, () => {
+            if (
+                game.ended
+                || game.state !== 'round'
+                || game.round?.id !== snapshot.roundId
+            ) return;
+            game.state = 'ended';
+            ownsRoundLimit = true;
+        });
+        if (!ownsRoundLimit) return false;
+
+        const expiryMessage = await queuePublicWrite(game, () => safeSend(
+            game,
+            { embeds: [makeEmbed(ROUND_LIMIT_DESCRIPTION)] },
+            'round-limit-expired'
+        ));
+        await cleanupDuelGame(game);
+        return Boolean(expiryMessage);
+    }
+
+    let nextRound = null;
+    await gameManager.runExclusive(game, () => {
+        if (game.ended || game.state !== 'round' || game.round?.id !== snapshot.roundId) return;
+        nextRound = createRound(game);
+        game.round = nextRound;
+    });
+    if (!nextRound) return false;
+    const delivered = await deliverRoundPanels(game, nextRound);
+    return delivered !== false;
+}
+
+async function handleRoundTimeout(game, roundId) {
+    let snapshot = null;
+    await gameManager.runExclusive(game, () => {
+        if (game.ended || game.state !== 'round' || game.round?.id !== roundId) return;
+        snapshot = claimRoundResolution(game, game.round, 'timeout');
+    });
+    return publishRoundResolution(game, snapshot);
+}
+
+async function expireInvitation(game) {
+    let expired = false;
+    await gameManager.runExclusive(game, () => {
+        if (game.ended || game.state !== 'inviting') return;
+        game.state = 'ended';
+        clearTimer(game, game.invitationTimer);
+        game.invitationTimer = null;
+        expired = true;
+    });
+    if (!expired) return false;
+    const description = '⌛ **死斗邀请已过期。**\n\n1 分钟内无人接受，本场死斗自动取消。';
+    const edited = await safeEdit(
+        game.inviteMessage,
+        invitationPayload(game, true, description),
+        game,
+        'invitation-timeout'
+    );
+    if (edited) game.componentsDisabled = true;
+    await cleanupDuelGame(game);
+    return true;
+}
+
+async function startDuel(interaction, requestedOpponent) {
+    const userId = interaction.user?.id;
+    const guildId = interaction.guildId || interaction.guild?.id;
+    const channelId = interaction.channelId;
+    const provisionalGame = {
+        id: randomUUID(),
+        type: 'duel',
+        guildId,
+        channelId,
+        guild: interaction.guild,
+        channel: interaction.channel,
+        initiatorId: userId,
+        participantIds: [userId],
+        requestedOpponentId: requestedOpponent?.id || requestedOpponent?.user?.id || null,
+        state: 'inviting',
+        timers: new Set(),
+        publicWriteQueue: Promise.resolve(),
+        originInteraction: interaction,
+    };
+
+    if (!await deferPublicStart(interaction, provisionalGame)) return false;
+
+    const initiator = await safeFetchMember(provisionalGame, userId);
+    if (!isCurrentGuildMember(provisionalGame, initiator, userId)) {
+        await rejectDeferredStart(
+            interaction,
+            isActivelyTimedOut(initiator) ? TIMEOUT_BLOCKED_MESSAGE : INVALID_INITIATOR_MESSAGE,
+            provisionalGame
+        );
+        return false;
+    }
+
+    let opponent = null;
+    if (provisionalGame.requestedOpponentId) {
+        if (
+            provisionalGame.requestedOpponentId === userId
+            || gameManager.getPlayerGame(guildId, provisionalGame.requestedOpponentId)
+        ) {
+            await rejectDeferredStart(interaction, INVALID_OPPONENT_MESSAGE, provisionalGame);
+            return false;
+        }
+        opponent = await safeFetchMember(provisionalGame, provisionalGame.requestedOpponentId);
+        if (!isCurrentGuildMember(
+            provisionalGame,
+            opponent,
+            provisionalGame.requestedOpponentId
+        )) {
+            await rejectDeferredStart(interaction, INVALID_OPPONENT_MESSAGE, provisionalGame);
+            return false;
+        }
+    }
+
+    let game;
+    provisionalGame.onMemberInvalidated = async invalidMember => {
+        const invalidUserId = invalidMember?.id || invalidMember?.user?.id;
+        if (invalidUserId) {
+            await handleDuelMemberInvalidated(game, invalidUserId, 'member-invalidated');
+        }
+    };
+    provisionalGame.disableComponents = () => {
+        if (!game?.componentsDisabled) void disableInvitation(game);
+    };
+
+    let finalPreflightRejection = null;
+    if (!isCurrentGuildMember(provisionalGame, initiator, userId)) {
+        finalPreflightRejection = isActivelyTimedOut(initiator)
+            ? TIMEOUT_BLOCKED_MESSAGE
+            : INVALID_INITIATOR_MESSAGE;
+    } else if (
+        provisionalGame.requestedOpponentId
+        && (
+            !isCurrentGuildMember(
+                provisionalGame,
+                opponent,
+                provisionalGame.requestedOpponentId
+            )
+            || gameManager.getPlayerGame(guildId, provisionalGame.requestedOpponentId)
+        )
+    ) {
+        finalPreflightRejection = INVALID_OPPONENT_MESSAGE;
+    }
+    if (finalPreflightRejection) {
+        await rejectDeferredStart(interaction, finalPreflightRejection, provisionalGame);
+        return false;
+    }
+
+    const created = gameManager.createGame(provisionalGame);
+    if (!created.ok) {
+        await rejectDeferredStart(
+            interaction,
+            created.reason === 'player' ? PLAYER_BUSY_MESSAGE : CHANNEL_BUSY_MESSAGE,
+            provisionalGame
+        );
+        return false;
+    }
+    game = created.game;
+
+    try {
+        const replyResult = await interaction.editReply(invitationPayload(game));
+        const responseMessage = replyResult?.resource?.message || replyResult;
+        if (typeof responseMessage?.edit === 'function') game.inviteMessage = responseMessage;
+    } catch (error) {
+        logDiscordFailure(game, 'invitation-panel', error, userId);
+        await cleanupDuelGame(game);
+        await rejectDeferredStart(interaction, GENERIC_FAILURE_MESSAGE, game);
+        return false;
+    }
+    if (!game.inviteMessage) {
+        try {
+            const fetched = await interaction.fetchReply?.();
+            if (typeof fetched?.edit === 'function') game.inviteMessage = fetched;
+        } catch (error) {
+            logDiscordFailure(game, 'fetch-invitation-panel', error, userId);
+        }
+    }
+    if (!game.inviteMessage && typeof interaction.editReply === 'function') {
+        game.inviteMessage = { edit: payload => interaction.editReply(payload) };
+    }
+    if (!game.inviteMessage) {
+        await cleanupDuelGame(game);
+        await rejectDeferredStart(interaction, GENERIC_FAILURE_MESSAGE, game);
+        return false;
+    }
+
+    game.invitationTimer = setTimeout(() => {
+        return expireInvitation(game).catch(error => {
+            logDiscordFailure(game, 'invitation-timer', error);
+            return cleanupDuelGame(game);
+        });
+    }, INVITATION_DURATION_MS);
+    game.invitationTimer.unref?.();
+    game.timers.add(game.invitationTimer);
+    return true;
+}
+
+function parseParts(parts) {
+    const input = (Array.isArray(parts) ? parts : [parts]).filter(part => typeof part === 'string');
+    const tokens = input.flatMap(part => part.split(':')).filter(Boolean);
+    if (tokens[0]?.startsWith('mystery_duel_')) {
+        tokens[0] = tokens[0].slice('mystery_duel_'.length);
+    }
+    while (tokens[0] === 'mystery' || tokens[0] === 'duel') tokens.shift();
+    return {
+        action: tokens[0],
+        gameId: tokens[1],
+        roundId: tokens[2],
+        choice: tokens[3],
+    };
+}
+
+async function handleAccept(interaction, game) {
+    const userId = interaction.user?.id;
+    let rejection = null;
+    await gameManager.runExclusive(game, () => {
+        if (game.ended || game.state !== 'inviting') rejection = EXPIRED_MESSAGE;
+        else if (userId === game.initiatorId) rejection = SELF_ACCEPT_MESSAGE;
+        else if (game.requestedOpponentId && userId !== game.requestedOpponentId) {
+            rejection = WRONG_INVITEE_MESSAGE;
+        }
+    });
+    if (rejection) {
+        await safeEphemeralReply(interaction, rejection, game);
+        return false;
+    }
+
+    const member = await safeFetchMember(game, userId);
+    let accepted = false;
+    let round = null;
+    await gameManager.runExclusive(game, () => {
+        if (game.ended || game.state !== 'inviting') {
+            rejection = EXPIRED_MESSAGE;
+            return;
+        }
+        if (userId === game.initiatorId) {
+            rejection = SELF_ACCEPT_MESSAGE;
+            return;
+        }
+        if (game.requestedOpponentId && userId !== game.requestedOpponentId) {
+            rejection = WRONG_INVITEE_MESSAGE;
+            return;
+        }
+        const owner = gameManager.getPlayerGame(game.guildId, userId);
+        if (owner && owner !== game) {
+            rejection = PLAYER_BUSY_MESSAGE;
+            return;
+        }
+        if (!isCurrentGuildMember(game, member, userId)) {
+            rejection = isActivelyTimedOut(member) ? TIMEOUT_BLOCKED_MESSAGE : INVALID_OPPONENT_MESSAGE;
+            return;
+        }
+        if (!gameManager.addPlayer(game, userId)) {
+            rejection = PLAYER_BUSY_MESSAGE;
+            return;
+        }
+
+        clearTimer(game, game.invitationTimer);
+        game.invitationTimer = null;
+        game.opponentId = userId;
+        game.opponentInteraction = interaction;
+        game.scores = { [game.initiatorId]: 0, [userId]: 0 };
+        game.state = 'round';
+        round = createRound(game);
+        game.round = round;
+        accepted = true;
+    });
+
+    if (!accepted) {
+        await safeEphemeralReply(interaction, rejection || EXPIRED_MESSAGE, game);
+        return false;
+    }
+
+    const invitationDisabled = await disableInvitationWithRetry(game);
+    if (!invitationDisabled) {
+        await gameManager.runExclusive(game, () => {
+            if (!game.ended && game.state === 'round' && game.round === round) {
+                game.state = 'ended';
+            }
+        });
+        await cleanupDuelGame(game);
+        await safeEphemeralReply(interaction, EXPIRED_MESSAGE, game);
+        return false;
+    }
+    const delivered = await deliverRoundPanels(game, round);
+    return delivered === true;
+}
+
+async function handleChoice(interaction, game, roundId, choice) {
+    const userId = interaction.user?.id;
+    let rejection = null;
+    let accepted = false;
+    let snapshot = null;
+    await gameManager.runExclusive(game, () => {
+        if (
+            game.ended
+            || game.state !== 'round'
+            || game.round?.id !== roundId
+            || !game.participantIds.includes(userId)
+        ) {
+            rejection = EXPIRED_MESSAGE;
+            return;
+        }
+        if (!Object.hasOwn(CHOICES, choice)) {
+            rejection = INVALID_CHOICE_MESSAGE;
+            return;
+        }
+        if (game.round.choices.has(userId)) {
+            rejection = DUPLICATE_CHOICE_MESSAGE;
+            return;
+        }
+        game.round.choices.set(userId, choice);
+        accepted = true;
+        if (game.round.choices.size === 2) {
+            snapshot = claimRoundResolution(game, game.round, 'choices');
+        }
+    });
+
+    if (!accepted) {
+        await safeEphemeralReply(interaction, rejection || EXPIRED_MESSAGE, game);
+        return false;
+    }
+
+    // The choice is authoritative once committed. A failed private acknowledgement
+    // must never roll it back, reopen the round, or prevent an owned settlement.
+    await safeEphemeralReply(interaction, CHOICE_RECORDED_MESSAGE, game);
+    if (snapshot) await publishRoundResolution(game, snapshot);
+    return true;
+}
+
+async function handleDuelInteraction(interaction, parts) {
+    const parsed = parseParts(parts);
+    const game = parsed.gameId && gameManager.getGame(parsed.gameId);
+    if (!await deferEphemeralComponent(interaction, game)) return false;
+    if (!game || game.type !== 'duel') {
+        await safeEphemeralReply(interaction, EXPIRED_MESSAGE, game);
+        return false;
+    }
+    if (parsed.action === 'accept') return handleAccept(interaction, game);
+    if (parsed.action === 'choice') {
+        return handleChoice(interaction, game, parsed.roundId, parsed.choice);
+    }
+    await safeEphemeralReply(interaction, EXPIRED_MESSAGE, game);
+    return false;
+}
+
+async function handleDuelMemberInvalidated(game, userId, reason) {
+    if (!game || game.type !== 'duel') return false;
+    let cancelled = false;
+    await gameManager.runExclusive(game, () => {
+        if (
+            game.ended
+            || game.state === 'ended'
+            || !game.participantIds.includes(userId)
+        ) return;
+        game.state = 'ended';
+        clearTimer(game, game.invitationTimer);
+        game.invitationTimer = null;
+        clearTimer(game, game.round?.timer);
+        if (game.round) game.round.timer = null;
+        game.invalidationReason = reason;
+        cancelled = true;
+    });
+    if (!cancelled) return false;
+
+    await queuePublicWrite(game, async () => {
+        if (game.opponentId) {
+            return safeSend(
+                game,
+                { embeds: [makeEmbed(INVALIDATED_DESCRIPTION)] },
+                'member-invalidated-cancel'
+            );
+        }
+        const edited = await safeEdit(
+            game.inviteMessage,
+            invitationPayload(game, true, INVALIDATED_DESCRIPTION),
+            game,
+            'initiator-invalidated-cancel'
+        );
+        if (edited) game.componentsDisabled = true;
+        return edited;
+    });
+    await cleanupDuelGame(game);
+    return true;
+}
+
+module.exports = {
+    startDuel,
+    handleDuelInteraction,
+    resolveChoices,
+    handleDuelMemberInvalidated,
+};

--- a/src/modules/mystery/services/interactionHandler.js
+++ b/src/modules/mystery/services/interactionHandler.js
@@ -1,0 +1,137 @@
+const { MessageFlags } = require('discord.js');
+const gameManager = require('./mysteryGameManager');
+const { handleRouletteInteraction } = require('./rouletteGame');
+const { handleBombInteraction } = require('./bombGame');
+const { handleDuelInteraction } = require('./duelGame');
+
+const MYSTERY_CUSTOM_ID_PREFIX = 'mystery_';
+const EXPIRED_INTERACTION_MESSAGE = '⌛ **这次游戏交互已经过期或失效了。**';
+const FAILED_INTERACTION_MESSAGE = '❌ **处理这次游戏操作时出了点问题，请稍后再试。**';
+const SIMPLE_ID_PATTERN = /^[A-Za-z0-9_-]{1,128}$/;
+
+const ROUTES = Object.freeze({
+    roulette: {
+        join: { component: 'button', partCount: 2 },
+    },
+    bomb: {
+        join: { component: 'button', partCount: 2 },
+        pass: { component: 'button', partCount: 3, tokenIndex: 2 },
+        target: { component: 'string', partCount: 3, tokenIndex: 2 },
+    },
+    duel: {
+        accept: { component: 'button', partCount: 2 },
+        choice: { component: 'button', partCount: 4 },
+    },
+});
+
+const DOWNSTREAM_HANDLERS = Object.freeze({
+    roulette: handleRouletteInteraction,
+    bomb: handleBombInteraction,
+    duel: handleDuelInteraction,
+});
+
+function componentKind(interaction) {
+    if (interaction?.isButton?.()) return 'button';
+    if (interaction?.isStringSelectMenu?.()) return 'string';
+    return null;
+}
+
+function parseMysteryCustomId(customId, kind) {
+    if (typeof customId !== 'string' || !customId.startsWith(MYSTERY_CUSTOM_ID_PREFIX)) {
+        return null;
+    }
+
+    const parts = customId.split(':');
+    const routeMatch = /^mystery_(roulette|bomb|duel)_([a-z]+)$/.exec(parts[0]);
+    if (!routeMatch) return { valid: false, parts };
+
+    const [, type, action] = routeMatch;
+    const route = ROUTES[type]?.[action];
+    const gameId = parts[1];
+    if (
+        !route
+        || route.component !== kind
+        || parts.length !== route.partCount
+        || !SIMPLE_ID_PATTERN.test(gameId || '')
+    ) {
+        return { valid: false, type, action, gameId, parts };
+    }
+
+    if (route.tokenIndex !== undefined && !/^\d+$/.test(parts[route.tokenIndex])) {
+        return { valid: false, type, action, gameId, parts };
+    }
+    if (type === 'duel' && action === 'choice') {
+        if (!SIMPLE_ID_PATTERN.test(parts[2] || '') || !['rock', 'scissors', 'paper'].includes(parts[3])) {
+            return { valid: false, type, action, gameId, parts };
+        }
+    }
+
+    return { valid: true, type, action, gameId, parts };
+}
+
+function logHandlerError(parsed, interaction, phase, error) {
+    const context = [
+        `type=${parsed?.type || 'unknown'}`,
+        `action=${parsed?.action || 'unknown'}`,
+        `game=${parsed?.gameId || 'unknown'}`,
+        `user=${interaction?.user?.id || 'unknown'}`,
+        `phase=${phase}`,
+    ].join(' ');
+    console.error(`[MysteryInteraction] ${context}`, error);
+}
+
+async function safePrivateResponse(interaction, content, parsed, phase) {
+    try {
+        if (interaction.deferred && !interaction.replied && typeof interaction.editReply === 'function') {
+            await interaction.editReply({ content });
+        } else if (interaction.replied && typeof interaction.followUp === 'function') {
+            await interaction.followUp({ content, flags: MessageFlags.Ephemeral });
+        } else if (!interaction.deferred && !interaction.replied && typeof interaction.reply === 'function') {
+            await interaction.reply({ content, flags: MessageFlags.Ephemeral });
+        } else {
+            return false;
+        }
+        return true;
+    } catch (error) {
+        logHandlerError(parsed, interaction, phase, error);
+        return false;
+    }
+}
+
+async function handleMysteryInteraction(interaction) {
+    const kind = componentKind(interaction);
+    if (!kind || typeof interaction?.customId !== 'string') return false;
+    if (!interaction.customId.startsWith(MYSTERY_CUSTOM_ID_PREFIX)) return false;
+
+    let parsed;
+    try {
+        parsed = parseMysteryCustomId(interaction.customId, kind);
+        const game = parsed?.valid && gameManager.getGame(parsed.gameId);
+        if (!parsed?.valid || !game || game.type !== parsed.type) {
+            await safePrivateResponse(
+                interaction,
+                EXPIRED_INTERACTION_MESSAGE,
+                parsed,
+                'expired-response'
+            );
+            return true;
+        }
+
+        await DOWNSTREAM_HANDLERS[parsed.type](interaction, parsed.parts);
+        return true;
+    } catch (error) {
+        logHandlerError(parsed, interaction, 'route', error);
+        await safePrivateResponse(
+            interaction,
+            FAILED_INTERACTION_MESSAGE,
+            parsed,
+            'failure-response'
+        );
+        return false;
+    }
+}
+
+module.exports = {
+    MYSTERY_CUSTOM_ID_PREFIX,
+    handleMysteryInteraction,
+};

--- a/src/modules/mystery/services/mysteryGameManager.js
+++ b/src/modules/mystery/services/mysteryGameManager.js
@@ -1,0 +1,207 @@
+const gamesById = new Map();
+const playerLocks = new Map();
+const channelLocks = new Map();
+
+function buildPlayerKey(guildId, userId) {
+    return `${guildId}:${userId}`;
+}
+
+function getGame(gameId) {
+    return gamesById.get(gameId);
+}
+
+function getPlayerGame(guildId, userId) {
+    return getGame(playerLocks.get(buildPlayerKey(guildId, userId)));
+}
+
+function getChannelGame(channelId) {
+    return getGame(channelLocks.get(channelId));
+}
+
+function createGame(input) {
+    const participantIds = [...new Set([input.initiatorId, ...input.participantIds])];
+
+    if (participantIds.some(userId => playerLocks.has(buildPlayerKey(input.guildId, userId)))) {
+        return { ok: false, reason: 'player' };
+    }
+
+    if (channelLocks.has(input.channelId)) {
+        return { ok: false, reason: 'channel' };
+    }
+
+    const game = {
+        ...input,
+        participantIds,
+        ended: false,
+        timers: input.timers || new Set(),
+    };
+    gamesById.set(game.id, game);
+    channelLocks.set(game.channelId, game.id);
+    participantIds.forEach(userId => {
+        playerLocks.set(buildPlayerKey(game.guildId, userId), game.id);
+    });
+
+    return { ok: true, game };
+}
+
+function addPlayer(game, userId) {
+    const playerKey = buildPlayerKey(game.guildId, userId);
+    const ownerId = playerLocks.get(playerKey);
+
+    if (game.ended || (ownerId !== undefined && ownerId !== game.id)) {
+        return false;
+    }
+
+    if (!game.participantIds.includes(userId)) {
+        game.participantIds.push(userId);
+    }
+    playerLocks.set(playerKey, game.id);
+    return true;
+}
+
+function removePlayer(game, userId) {
+    const playerKey = buildPlayerKey(game.guildId, userId);
+    const index = game.participantIds.indexOf(userId);
+
+    if (index === -1) {
+        return false;
+    }
+
+    game.participantIds.splice(index, 1);
+    if (playerLocks.get(playerKey) === game.id) {
+        playerLocks.delete(playerKey);
+    }
+    return true;
+}
+
+function runExclusive(game, operation) {
+    const previous = game.operationQueue || Promise.resolve();
+    let releaseGate;
+    const gate = new Promise(resolve => {
+        releaseGate = resolve;
+    });
+    game.operationQueue = gate;
+
+    return previous.then(async () => {
+        try {
+            return await operation();
+        } finally {
+            releaseGate();
+            if (game.operationQueue === gate) {
+                delete game.operationQueue;
+            }
+        }
+    });
+}
+
+async function cleanupGame(game) {
+    let ownsCleanup = false;
+    await runExclusive(game, () => {
+        if (game.ended) {
+            return;
+        }
+
+        game.ended = true;
+        ownsCleanup = true;
+        for (const timer of game.timers) {
+            clearTimeout(timer);
+        }
+        game.timers.clear?.();
+    });
+
+    if (!ownsCleanup) return;
+
+    try {
+        void Promise.resolve(game.disableComponents?.()).catch(() => {
+            // Component cleanup is best effort; lock release must still occur.
+        });
+    } catch (error) {
+        // Synchronous component cleanup failures are also best effort.
+    }
+
+    await runExclusive(game, () => {
+        game.participantIds.forEach(userId => {
+            const playerKey = buildPlayerKey(game.guildId, userId);
+            if (playerLocks.get(playerKey) === game.id) {
+                playerLocks.delete(playerKey);
+            }
+        });
+        if (channelLocks.get(game.channelId) === game.id) {
+            channelLocks.delete(game.channelId);
+        }
+        if (gamesById.get(game.id) === game) {
+            gamesById.delete(game.id);
+        }
+    });
+}
+
+function getMemberIds(member) {
+    return {
+        guildId: member.guildId || member.guild?.id,
+        userId: member.id || member.user?.id,
+    };
+}
+
+function logInvalidationFailure(game, userId, action, error) {
+    console.error(
+        `[MysteryGameManager] ${action} (guild=${game?.guildId || 'unknown'}, user=${userId || 'unknown'}, game=${game?.id || 'unknown'}, type=${game?.type || 'unknown'}):`,
+        error
+    );
+}
+
+async function dispatchMemberInvalidation(member, ...args) {
+    const { guildId, userId } = getMemberIds(member);
+    if (!guildId || !userId) {
+        return;
+    }
+
+    const game = getPlayerGame(guildId, userId);
+    if (!game) {
+        return;
+    }
+
+    game.invalidatedMemberIds ||= new Set();
+    if (game.invalidatedMemberIds.has(userId)) {
+        return;
+    }
+    game.invalidatedMemberIds.add(userId);
+
+    try {
+        await game.onMemberInvalidated?.(member, ...args);
+    } catch (error) {
+        logInvalidationFailure(game, userId, 'member invalidation callback failed', error);
+        try {
+            await cleanupGame(game);
+        } catch (cleanupError) {
+            logInvalidationFailure(game, userId, 'fallback cleanup failed', cleanupError);
+        }
+    }
+}
+
+function handleGuildMemberRemove(member) {
+    return dispatchMemberInvalidation(member);
+}
+
+function handleGuildMemberUpdate(oldMember, newMember) {
+    return dispatchMemberInvalidation(newMember, oldMember);
+}
+
+function resetForTests() {
+    gamesById.clear();
+    playerLocks.clear();
+    channelLocks.clear();
+}
+
+module.exports = {
+    createGame,
+    getGame,
+    getPlayerGame,
+    getChannelGame,
+    addPlayer,
+    removePlayer,
+    runExclusive,
+    cleanupGame,
+    handleGuildMemberRemove,
+    handleGuildMemberUpdate,
+    resetForTests,
+};

--- a/src/modules/mystery/services/namePoolManager.js
+++ b/src/modules/mystery/services/namePoolManager.js
@@ -1,0 +1,276 @@
+const {
+    ActionRowBuilder,
+    ButtonBuilder,
+    ButtonStyle,
+    EmbedBuilder,
+    MessageFlags,
+    ModalBuilder,
+    StringSelectMenuBuilder,
+    TextInputBuilder,
+    TextInputStyle,
+} = require('discord.js');
+const namePoolStore = require('./namePoolStore');
+const {
+    checkAdminPermission,
+    getPermissionDeniedMessage,
+} = require('../../../core/utils/permissionManager');
+
+const NAME_POOL_CUSTOM_ID_PREFIX = 'mystery_namepool:';
+const PAGE_SIZE = 25;
+const EXPIRED_MESSAGE = '⏱️ **这个名字库管理页面已经过期或无效。**\n请重新使用 `/管理 神秘名字库`。';
+const FAILURE_MESSAGE = '❌ **名字库操作失败。**\n数据没有被修改，请稍后重试。';
+const EMPTY_REJECTION_MESSAGE = '❌ **不能把神秘名字库删空。**\n\n至少需要保留 **1 个名字**，\n否则 `/神秘指令 取名字好麻烦` 将无法正常使用。';
+
+function mainPanelPayload(total) {
+    const embed = new EmbedBuilder()
+        .setTitle('📚 神秘名字库管理')
+        .setDescription([
+            `当前共有 **${total} 个名字**。`,
+            '',
+            '这里的修改会立即影响：',
+            '`/神秘指令 取名字好麻烦`',
+            '',
+            '名字库为全 Bot 共用，不区分服务器。',
+        ].join('\n'));
+    const row = new ActionRowBuilder().addComponents(
+        new ButtonBuilder()
+            .setCustomId('mystery_namepool:add')
+            .setLabel('添加名字')
+            .setEmoji('➕')
+            .setStyle(ButtonStyle.Success),
+        new ButtonBuilder()
+            .setCustomId('mystery_namepool:delete_page:0')
+            .setLabel('删除名字')
+            .setEmoji('➖')
+            .setStyle(ButtonStyle.Danger),
+        new ButtonBuilder()
+            .setCustomId('mystery_namepool:batch_delete')
+            .setLabel('批量删除')
+            .setEmoji('🗑️')
+            .setStyle(ButtonStyle.Danger),
+        new ButtonBuilder()
+            .setCustomId('mystery_namepool:view_page:0')
+            .setLabel('查看名字库')
+            .setEmoji('📋')
+            .setStyle(ButtonStyle.Secondary),
+    );
+    return { embeds: [embed], components: [row] };
+}
+
+function createNamesModal({ customId, title, label, placeholder }) {
+    const input = new TextInputBuilder()
+        .setCustomId('names')
+        .setLabel(label)
+        .setPlaceholder(placeholder)
+        .setStyle(TextInputStyle.Paragraph)
+        .setRequired(true)
+        .setMaxLength(4000);
+    return new ModalBuilder()
+        .setCustomId(customId)
+        .setTitle(title)
+        .addComponents(new ActionRowBuilder().addComponents(input));
+}
+
+function clampPage(page, total) {
+    const pageCount = Math.max(1, Math.ceil(total / PAGE_SIZE));
+    return { page: Math.min(page, pageCount - 1), pageCount };
+}
+
+function deletePagePayload(names, requestedPage, content) {
+    const { page, pageCount } = clampPage(requestedPage, names.length);
+    const pageNames = names.slice(page * PAGE_SIZE, (page + 1) * PAGE_SIZE);
+    const embed = new EmbedBuilder()
+        .setTitle('➖ 删除神秘名字')
+        .setDescription(`第 ${page + 1} / ${pageCount} 页\n当前名字总数：${names.length}\n\n请选择要删除的名字，可多选。`);
+    const select = new StringSelectMenuBuilder()
+        .setCustomId(`mystery_namepool:delete_select:${page}`)
+        .setPlaceholder('选择要删除的名字')
+        .setMinValues(1)
+        .setMaxValues(pageNames.length)
+        .addOptions(pageNames.map(name => ({ label: name, value: name })));
+    const navigation = new ActionRowBuilder().addComponents(
+        new ButtonBuilder()
+            .setCustomId(`mystery_namepool:delete_page:${Math.max(0, page - 1)}`)
+            .setLabel('上一页')
+            .setEmoji('⬅️')
+            .setStyle(ButtonStyle.Secondary)
+            .setDisabled(page === 0),
+        new ButtonBuilder()
+            .setCustomId(`mystery_namepool:delete_page:${Math.min(pageCount - 1, page + 1)}`)
+            .setLabel('下一页')
+            .setEmoji('➡️')
+            .setStyle(ButtonStyle.Secondary)
+            .setDisabled(page === pageCount - 1),
+    );
+    return {
+        ...(content ? { content } : {}),
+        embeds: [embed],
+        components: [new ActionRowBuilder().addComponents(select), navigation],
+    };
+}
+
+function viewPagePayload(names, requestedPage) {
+    const { page, pageCount } = clampPage(requestedPage, names.length);
+    const pageNames = names.slice(page * PAGE_SIZE, (page + 1) * PAGE_SIZE);
+    const lines = pageNames.map((name, index) => `${page * PAGE_SIZE + index + 1}. ${name}`);
+    const embed = new EmbedBuilder()
+        .setTitle('📋 神秘名字库')
+        .setDescription(lines.join('\n'))
+        .setFooter({ text: `当前总数：${names.length} · 第 ${page + 1} / ${pageCount} 页` });
+    const navigation = new ActionRowBuilder().addComponents(
+        new ButtonBuilder()
+            .setCustomId(`mystery_namepool:view_page:${Math.max(0, page - 1)}`)
+            .setLabel('上一页')
+            .setEmoji('⬅️')
+            .setStyle(ButtonStyle.Secondary)
+            .setDisabled(page === 0),
+        new ButtonBuilder()
+            .setCustomId(`mystery_namepool:view_page:${Math.min(pageCount - 1, page + 1)}`)
+            .setLabel('下一页')
+            .setEmoji('➡️')
+            .setStyle(ButtonStyle.Secondary)
+            .setDisabled(page === pageCount - 1),
+    );
+    return { embeds: [embed], components: [navigation] };
+}
+
+async function safePrivateResponse(interaction, payload) {
+    try {
+        if (interaction.deferred && typeof interaction.editReply === 'function') {
+            await interaction.editReply(payload);
+        } else if (interaction.replied && typeof interaction.followUp === 'function') {
+            await interaction.followUp({ ...payload, flags: MessageFlags.Ephemeral });
+        } else if (typeof interaction.reply === 'function') {
+            await interaction.reply({ ...payload, flags: MessageFlags.Ephemeral });
+        }
+    } catch (error) {
+        console.error('[MysteryNamePool] 发送私密回复失败:', error);
+    }
+}
+
+function createNamePoolManager({
+    store = namePoolStore,
+    checkPermission = checkAdminPermission,
+    permissionDeniedMessage = getPermissionDeniedMessage,
+} = {}) {
+    async function openNamePoolManager(interaction) {
+        if (!checkPermission(interaction.member)) {
+            await safePrivateResponse(interaction, { content: permissionDeniedMessage() });
+            return;
+        }
+        try {
+            const names = await store.getNames();
+            await interaction.reply({ ...mainPanelPayload(names.length), flags: MessageFlags.Ephemeral });
+        } catch (error) {
+            console.error('[MysteryNamePool] 打开管理面板失败:', error);
+            await safePrivateResponse(interaction, { content: FAILURE_MESSAGE });
+        }
+    }
+
+    async function handleNamePoolInteraction(interaction) {
+        if (!checkPermission(interaction.member)) {
+            await safePrivateResponse(interaction, { content: permissionDeniedMessage() });
+            return true;
+        }
+        const customId = interaction.customId;
+        if (typeof customId !== 'string' || !customId.startsWith(NAME_POOL_CUSTOM_ID_PREFIX)) return false;
+
+        try {
+            if (interaction.isButton?.() && customId === 'mystery_namepool:add') {
+                await interaction.showModal(createNamesModal({
+                    customId: 'mystery_namepool:add_modal',
+                    title: '添加神秘名字',
+                    label: '一行一个名字',
+                    placeholder: '我是大聪明\n今天不想取名\n神秘路人甲',
+                }));
+                return true;
+            }
+            if (interaction.isButton?.() && customId === 'mystery_namepool:batch_delete') {
+                await interaction.showModal(createNamesModal({
+                    customId: 'mystery_namepool:batch_delete_modal',
+                    title: '批量删除神秘名字',
+                    label: '一行一个名字',
+                    placeholder: '嘉豪\n我是大聪明\n神秘路人甲',
+                }));
+                return true;
+            }
+            if (interaction.isModalSubmit?.() && customId === 'mystery_namepool:add_modal') {
+                await interaction.deferReply({ flags: MessageFlags.Ephemeral });
+                const result = await store.addNames(interaction.fields.getTextInputValue('names').split(/\r?\n/));
+                await interaction.editReply({
+                    content: [
+                        '✅ **名字库已更新**', '',
+                        `成功添加：**${result.added} 个**`,
+                        `重复跳过：**${result.duplicates} 个**`,
+                        `无效跳过：**${result.invalid} 个**`, '',
+                        `当前总数：**${result.total} 个**`,
+                    ].join('\n'),
+                });
+                return true;
+            }
+            if (interaction.isModalSubmit?.() && customId === 'mystery_namepool:batch_delete_modal') {
+                await interaction.deferReply({ flags: MessageFlags.Ephemeral });
+                const result = await store.removeNames(interaction.fields.getTextInputValue('names').split(/\r?\n/));
+                if (result.rejectedEmpty) {
+                    await interaction.editReply({ content: EMPTY_REJECTION_MESSAGE });
+                } else {
+                    await interaction.editReply({
+                        content: [
+                            '🗑️ **名字库已更新**', '',
+                            `成功删除：**${result.removed} 个**`,
+                            `未找到：**${result.notFound} 个**`, '',
+                            `当前剩余：**${result.total} 个**`,
+                        ].join('\n'),
+                    });
+                }
+                return true;
+            }
+
+            const deletePageMatch = /^mystery_namepool:delete_page:(\d+)$/.exec(customId);
+            if (interaction.isButton?.() && deletePageMatch) {
+                await interaction.deferUpdate();
+                const names = await store.getNames();
+                await interaction.editReply(deletePagePayload(names, Number(deletePageMatch[1])));
+                return true;
+            }
+            const viewPageMatch = /^mystery_namepool:view_page:(\d+)$/.exec(customId);
+            if (interaction.isButton?.() && viewPageMatch) {
+                await interaction.deferUpdate();
+                const names = await store.getNames();
+                await interaction.editReply(viewPagePayload(names, Number(viewPageMatch[1])));
+                return true;
+            }
+            const deleteSelectMatch = /^mystery_namepool:delete_select:(\d+)$/.exec(customId);
+            if (interaction.isStringSelectMenu?.() && deleteSelectMatch) {
+                await interaction.deferUpdate();
+                const result = await store.removeNames(interaction.values);
+                if (result.rejectedEmpty) {
+                    await interaction.editReply({ content: EMPTY_REJECTION_MESSAGE, embeds: [], components: [] });
+                } else {
+                    const names = await store.getNames();
+                    const status = `🗑️ 成功删除：**${result.removed} 个** · 未找到：**${result.notFound} 个**`;
+                    await interaction.editReply(deletePagePayload(names, Number(deleteSelectMatch[1]), status));
+                }
+                return true;
+            }
+
+            await safePrivateResponse(interaction, { content: EXPIRED_MESSAGE });
+            return true;
+        } catch (error) {
+            console.error(`[MysteryNamePool] 处理交互失败 (customId=${customId}):`, error);
+            await safePrivateResponse(interaction, { content: FAILURE_MESSAGE });
+            return true;
+        }
+    }
+
+    return { openNamePoolManager, handleNamePoolInteraction };
+}
+
+const defaultManager = createNamePoolManager();
+
+module.exports = {
+    NAME_POOL_CUSTOM_ID_PREFIX,
+    createNamePoolManager,
+    openNamePoolManager: defaultManager.openNamePoolManager,
+    handleNamePoolInteraction: defaultManager.handleNamePoolInteraction,
+};

--- a/src/modules/mystery/services/namePoolStore.js
+++ b/src/modules/mystery/services/namePoolStore.js
@@ -1,0 +1,223 @@
+const fs = require('node:fs/promises');
+const path = require('node:path');
+
+const VERSION = 1;
+const MAX_NICKNAME_LENGTH = 32;
+let corruptSequence = 0;
+
+const DEFAULT_NAME_POOL = Object.freeze([
+    '我是奶人', '奶奶的龙', '铁血旅程派', '铁血类脑派', '权蛆', 'D喵梦男', 'D喵梦女',
+    '大狗叫！', '猪猪之王', '类脑自研文爱AI', '赛博街溜子', '名字被狗吃了',
+    '管理组重点观察对象', '用户名涉嫌违规', '类脑最纯洁之人', '类脑最淫乱之人', '基米',
+    '我不是gay', '我是好女孩吗', '类脑第一深情', '名字已被夺舍', '疑似真人',
+    '别问我为什么叫这个', '嘉豪本豪', '我现在后悔还来得及吗', '嘉豪',
+]);
+
+function isValidName(name) {
+    return typeof name === 'string'
+        && name.length > 0
+        && name === name.trim()
+        && Array.from(name).length <= MAX_NICKNAME_LENGTH;
+}
+
+function parseSnapshot(serialized) {
+    const value = JSON.parse(serialized);
+    if (!value || Array.isArray(value) || value.version !== VERSION || !Array.isArray(value.names)) {
+        throw new Error('Name pool must contain version 1 and a names array');
+    }
+    if (value.names.length === 0 || value.names.some(name => !isValidName(name))) {
+        throw new Error('Name pool must contain at least one valid Discord nickname');
+    }
+    if (new Set(value.names).size !== value.names.length) {
+        throw new Error('Name pool names must be unique');
+    }
+    return [...value.names];
+}
+
+function createNamePoolStore({
+    filePath,
+    fsImpl = fs,
+    now = Date.now,
+}) {
+    let names = [...DEFAULT_NAME_POOL];
+    let initialized = false;
+    let initializationPromise = null;
+    let mutationTail = Promise.resolve();
+
+    async function ensureDirectory() {
+        await fsImpl.mkdir(path.dirname(filePath), { recursive: true });
+    }
+
+    async function writeNames(nextNames) {
+        await ensureDirectory();
+        const temporaryPath = `${filePath}.tmp`;
+        const serialized = `${JSON.stringify({ version: VERSION, names: nextNames }, null, 2)}\n`;
+        try {
+            await fsImpl.writeFile(temporaryPath, serialized, 'utf8');
+            await fsImpl.rename(temporaryPath, filePath);
+        } catch (error) {
+            try {
+                await fsImpl.unlink(temporaryPath);
+            } catch (cleanupError) {
+                if (cleanupError.code !== 'ENOENT') {
+                    console.error('[namePoolStore] 清理临时文件失败:', cleanupError);
+                }
+            }
+            throw error;
+        }
+    }
+
+    async function backupCorruptFile() {
+        const parsed = path.parse(filePath);
+        const timestamp = (now() * 1000) + (corruptSequence++ % 1000);
+        const backupPath = path.join(parsed.dir, `${parsed.name}.corrupt-${timestamp}${parsed.ext}`);
+        await fsImpl.rename(filePath, backupPath);
+        return backupPath;
+    }
+
+    async function performInitialization() {
+        await ensureDirectory();
+        let serialized;
+        try {
+            serialized = await fsImpl.readFile(filePath, 'utf8');
+        } catch (error) {
+            if (error.code !== 'ENOENT') throw error;
+            const defaults = [...DEFAULT_NAME_POOL];
+            await writeNames(defaults);
+            names = defaults;
+            initialized = true;
+            return;
+        }
+
+        try {
+            names = parseSnapshot(serialized);
+        } catch (error) {
+            console.error('[namePoolStore] 名字库 JSON 损坏，正在恢复默认名字库:', error);
+            await backupCorruptFile();
+            const defaults = [...DEFAULT_NAME_POOL];
+            await writeNames(defaults);
+            names = defaults;
+        }
+        initialized = true;
+    }
+
+    async function initialize() {
+        if (initialized) return;
+        if (!initializationPromise) {
+            initializationPromise = performInitialization().catch(error => {
+                initializationPromise = null;
+                throw error;
+            });
+        }
+        await initializationPromise;
+    }
+
+    async function getNames() {
+        await initialize();
+        return [...names];
+    }
+
+    function serializeMutation(operation) {
+        const result = mutationTail.then(operation, operation);
+        mutationTail = result.catch(() => {});
+        return result;
+    }
+
+    async function addNames(inputNames) {
+        return serializeMutation(async () => {
+            await initialize();
+            const existing = new Set(names);
+            const seenInput = new Set();
+            const additions = [];
+            let duplicates = 0;
+            let invalid = 0;
+
+            for (const rawName of Array.isArray(inputNames) ? inputNames : []) {
+                const name = typeof rawName === 'string' ? rawName.trim() : '';
+                if (!name || Array.from(name).length > MAX_NICKNAME_LENGTH) {
+                    invalid += 1;
+                    continue;
+                }
+                if (seenInput.has(name) || existing.has(name)) {
+                    duplicates += 1;
+                    continue;
+                }
+                seenInput.add(name);
+                existing.add(name);
+                additions.push(name);
+            }
+
+            if (additions.length > 0) {
+                const nextNames = [...names, ...additions];
+                await writeNames(nextNames);
+                names = nextNames;
+            }
+            return {
+                added: additions.length,
+                duplicates,
+                invalid,
+                total: names.length,
+            };
+        });
+    }
+
+    async function removeNames(inputNames) {
+        return serializeMutation(async () => {
+            await initialize();
+            const requested = [];
+            const seen = new Set();
+            for (const rawName of Array.isArray(inputNames) ? inputNames : []) {
+                const name = typeof rawName === 'string' ? rawName.trim() : '';
+                if (!name || seen.has(name)) continue;
+                seen.add(name);
+                requested.push(name);
+            }
+
+            const current = new Set(names);
+            const found = requested.filter(name => current.has(name));
+            const notFound = requested.length - found.length;
+            if (found.length === names.length) {
+                return {
+                    removed: 0,
+                    notFound,
+                    total: names.length,
+                    rejectedEmpty: true,
+                };
+            }
+
+            if (found.length > 0) {
+                const removing = new Set(found);
+                const nextNames = names.filter(name => !removing.has(name));
+                await writeNames(nextNames);
+                names = nextNames;
+            }
+            return {
+                removed: found.length,
+                notFound,
+                total: names.length,
+                rejectedEmpty: false,
+            };
+        });
+    }
+
+    return {
+        initialize,
+        getNames,
+        addNames,
+        removeNames,
+    };
+}
+
+const defaultStore = createNamePoolStore({
+    filePath: path.join('data', 'mystery', 'namePool.json'),
+});
+
+module.exports = {
+    DEFAULT_NAME_POOL,
+    MAX_NICKNAME_LENGTH,
+    createNamePoolStore,
+    initialize: defaultStore.initialize,
+    getNames: defaultStore.getNames,
+    addNames: defaultStore.addNames,
+    removeNames: defaultStore.removeNames,
+};

--- a/src/modules/mystery/services/rouletteGame.js
+++ b/src/modules/mystery/services/rouletteGame.js
@@ -1,0 +1,771 @@
+const { randomUUID } = require('node:crypto');
+const {
+    ActionRowBuilder,
+    ButtonBuilder,
+    ButtonStyle,
+    EmbedBuilder,
+    MessageFlags,
+} = require('discord.js');
+const gameManager = require('./mysteryGameManager');
+
+const RECRUITMENT_DURATION_MS = 3 * 60 * 1000;
+const RESULT_REVEAL_DELAY_MS = 5 * 1000;
+const ROULETTE_TIMEOUT_DURATION_MS = 5 * 60 * 1000;
+const ROULETTE_TIMEOUT_REASON = '神秘指令：运气轮盘';
+const MAX_PARTICIPANTS = 6;
+const MIN_PARTICIPANTS = 3;
+
+const PLAYER_BUSY_MESSAGE = '🚫 **一心不能二用。**\n你现在已经在一场神秘游戏里，先把那边活着玩完再说。';
+const CHANNEL_BUSY_MESSAGE = '🎮 **这里已经有一场游戏在进行了。**\n等当前游戏结束后再开新的吧。';
+const TIMEOUT_BLOCKED_MESSAGE = '🎰 **轮盘拒绝了你。**\n你当前还在禁言，暂时无法参加。';
+const INVALID_MEMBER_MESSAGE = '⚠️ **你现在无法参加这场运气轮盘。**';
+const EXPIRED_MESSAGE = '⌛ **这场运气轮盘已经结束或失效了。**';
+const FULL_MESSAGE = '🎰 **这场运气轮盘已经满员了。**';
+const DUPLICATE_MESSAGE = '👀 **你已经参加这场游戏了。**\n再点也不会增加中奖概率。';
+const JOINED_MESSAGE = '✅ **你已加入运气轮盘**\n\n接下来就看命了。';
+const JOIN_FAILURE_MESSAGE = '❌ **参加运气轮盘失败了。**\n请稍后再试。';
+
+function logDiscordFailure(game, action, error, userId = 'system') {
+    console.error(
+        `[MysteryRoulette] Discord API 失败 (guild=${game?.guildId || 'unknown'}, game=${game?.id || 'unknown'}, user=${userId}, action=${action}):`,
+        error
+    );
+}
+
+function recruitmentDescription(game) {
+    return [
+        '🎰 **运气轮盘已开启**',
+        '',
+        `<@${game.initiatorId}> 发起了一场运气轮盘，并已自动加入游戏。`,
+        '',
+        '**游戏规则**',
+        '- 本游戏为自愿参加，点击按钮即视为接受游戏规则',
+        '- 最少 **3 人**、最多 **6 人**',
+        '- 满 **6 人**立即开始',
+        '- 未满 6 人将在 **3 分钟后**尝试开始',
+        '- 游戏开始后，将从参与者中随机挑选一名“幸运儿”',
+        '- 被选中的玩家将被 **禁言 5 分钟**',
+        '',
+        `**当前人数：${game.participantIds.length} / 6**`,
+    ].join('\n');
+}
+
+function cancellationDescription() {
+    return [
+        '🥀 **运气轮盘开不起来了**',
+        '',
+        '等待 3 分钟后，本轮仍未达到最低 **3 人**。',
+        '',
+        '本轮游戏自动取消。',
+        '',
+        '看来今天大家都很珍惜自己的发言权。',
+    ].join('\n');
+}
+
+function startingDescription(participantIds) {
+    const mentions = participantIds.map(userId => `<@${userId}>`).join('、');
+    return [
+        '🎰 **轮盘开始转动……**',
+        '',
+        '**本局参与者：**',
+        mentions,
+        '',
+        `本局共有 **${participantIds.length} 名玩家**。`,
+        '',
+        '正在从各位勇士之中挑选幸运儿……',
+        '',
+        '**祝你好运。**',
+        '',
+        '*或者祝别人好运。*',
+    ].join('\n');
+}
+
+function ordinaryResultDescription(userId, timeoutFailed) {
+    const lines = [
+        '🎉 **恭喜幸运儿诞生！**',
+        '',
+        '在本轮运气轮盘中，',
+        '',
+        `🎯 **<@${userId}>**`,
+        '',
+        '成功从所有参与者中脱颖而出！',
+        '',
+        '奖励是：',
+        '**禁言 5 分钟。**',
+        '',
+        '感谢其他玩家陪跑。',
+    ];
+    if (timeoutFailed) {
+        lines.push('', '🛡️ **但禁言被神秘力量阻挡，未能生效。**');
+    }
+    return lines.join('\n');
+}
+
+function allWinnersResultDescription(hasTimeoutFailures) {
+    const lines = [
+        '🚨 **等等，好像哪里不对……**',
+        '',
+        '轮盘在最后一刻突然失控。',
+        '',
+        '本轮似乎没有选出幸运儿。',
+        '',
+        '因为——',
+        '',
+        '🎰 **恭喜，全员中奖。**',
+        '',
+        '本局所有参与者将被 **禁言 5 分钟**。',
+        '',
+        '*看来今天的幸运比较平均。*',
+    ];
+    if (hasTimeoutFailures) {
+        lines.push('', '🛡️ **部分禁言被神秘力量阻挡，未能生效。**');
+    }
+    return lines.join('\n');
+}
+
+function makeEmbed(description) {
+    return new EmbedBuilder().setDescription(description);
+}
+
+function joinRow(gameId, disabled = false) {
+    return new ActionRowBuilder().addComponents(
+        new ButtonBuilder()
+            .setCustomId(`mystery_roulette_join:${gameId}`)
+            .setLabel('🎰 自愿参加')
+            .setStyle(ButtonStyle.Primary)
+            .setDisabled(disabled)
+    );
+}
+
+function recruitmentPayload(game, disabled = false) {
+    return {
+        embeds: [makeEmbed(recruitmentDescription(game))],
+        components: [joinRow(game.id, disabled)],
+    };
+}
+
+async function deferReply(interaction, payload, game, action) {
+    try {
+        await interaction.deferReply(payload);
+        return true;
+    } catch (error) {
+        logDiscordFailure(game, action, error, interaction.user?.id);
+        return false;
+    }
+}
+
+async function replacePublicDeferWithEphemeral(interaction, content, game) {
+    try {
+        await interaction.deleteReply();
+    } catch (error) {
+        logDiscordFailure(game, 'delete-public-defer', error, interaction.user?.id);
+    }
+    try {
+        await interaction.followUp({ content, flags: MessageFlags.Ephemeral });
+    } catch (error) {
+        logDiscordFailure(game, 'ephemeral-follow-up', error, interaction.user?.id);
+    }
+}
+
+async function safeDeferredReplyEdit(interaction, content, game) {
+    try {
+        await interaction.editReply({ content });
+    } catch (error) {
+        logDiscordFailure(game, 'ephemeral-edit-reply', error, interaction.user?.id);
+    }
+}
+
+function isActivelyTimedOut(member, now = Date.now()) {
+    return Number(member?.communicationDisabledUntilTimestamp) > now;
+}
+
+function isValidHumanMember(member) {
+    return Boolean(member?.id && member.user && !member.user.bot && !isActivelyTimedOut(member));
+}
+
+async function fetchMember(game, userId) {
+    try {
+        return await game.guild.members.fetch(userId);
+    } catch (error) {
+        logDiscordFailure(game, 'fetch-member', error, userId);
+        return null;
+    }
+}
+
+function drawRouletteOutcome(participantIds, random = Math.random) {
+    const ids = [...participantIds];
+    if (ids.length === 0) {
+        return { allWinners: false, selectedIds: [] };
+    }
+    if (random() < 0.05) {
+        return { allWinners: true, selectedIds: ids };
+    }
+    const index = Math.min(ids.length - 1, Math.floor(random() * ids.length));
+    return { allWinners: false, selectedIds: [ids[Math.max(0, index)]] };
+}
+
+async function editPublicPanel(game, payload, action) {
+    return editMessage(game, game.message, payload, action);
+}
+
+async function editMessage(game, message, payload, action) {
+    if (!message || typeof message.edit !== 'function') return false;
+    try {
+        await message.edit(payload);
+        return true;
+    } catch (error) {
+        logDiscordFailure(game, action, error);
+        return false;
+    }
+}
+
+async function sendPublicPanel(game, payload, action) {
+    if (!game.channel || typeof game.channel.send !== 'function') return null;
+    try {
+        return await game.channel.send(payload);
+    } catch (error) {
+        logDiscordFailure(game, action, error);
+        return null;
+    }
+}
+
+function waitForResultReveal(game) {
+    if (game.ended || game.state !== 'starting') return Promise.resolve(false);
+    return new Promise(resolve => {
+        let finished = false;
+        let timer;
+        const finish = revealed => {
+            if (finished) return;
+            finished = true;
+            clearTimeout(timer);
+            game.timers.delete(timer);
+            if (game.resultReveal?.timer === timer) game.resultReveal = null;
+            resolve(revealed);
+        };
+        timer = setTimeout(() => finish(true), game.resultRevealDelayMs);
+        timer.unref?.();
+        game.timers.add(timer);
+        game.resultReveal = { timer, finish };
+    });
+}
+
+function cancelResultReveal(game) {
+    if (!game?.resultReveal) return false;
+    game.resultReveal.finish(false);
+    return true;
+}
+
+function queueRecruitmentPanelEdit(game, action, finalize) {
+    const version = (game.recruitmentPanelVersion || 0) + 1;
+    game.recruitmentPanelVersion = version;
+    const previous = game.recruitmentPanelQueue || Promise.resolve();
+    const operation = previous
+        .catch(error => {
+            logDiscordFailure(game, 'recruitment-panel-queue', error);
+        })
+        .then(async () => {
+            let result;
+            if (game.ended || game.state !== 'recruiting') {
+                result = { updated: false, stale: true };
+            } else {
+                result = {
+                    updated: await editPublicPanel(game, recruitmentPayload(game), action),
+                    stale: false,
+                };
+            }
+            await finalize?.(result);
+            return result;
+        })
+        .catch(error => {
+            logDiscordFailure(game, 'recruitment-panel-queue', error);
+            return { updated: false, stale: true };
+        })
+        .finally(() => {
+            game.recruitmentPanelCompletedVersion = Math.max(
+                game.recruitmentPanelCompletedVersion || 0,
+                version
+            );
+        });
+    game.recruitmentPanelQueue = operation;
+    return operation;
+}
+
+async function waitForRecruitmentPanelQueue(game) {
+    try {
+        await game.recruitmentPanelQueue;
+    } catch (error) {
+        logDiscordFailure(game, 'recruitment-panel-queue-wait', error);
+    }
+}
+
+function scheduleComponentDisable(game) {
+    if (!game || game.componentsDisabled || !game.message) {
+        return Promise.resolve(game?.componentsDisabled === true);
+    }
+    if (game.componentDisablePromise) return game.componentDisablePromise;
+
+    let operation;
+    operation = (async () => {
+        await waitForRecruitmentPanelQueue(game);
+        if (game.componentsDisabled) return true;
+        const disabled = await editPublicPanel(game, {
+            components: [joinRow(game.id, true)],
+        }, 'disable-components');
+        if (disabled) game.componentsDisabled = true;
+        return disabled;
+    })()
+        .catch(error => {
+            logDiscordFailure(game, 'disable-components', error);
+            return false;
+        })
+        .finally(() => {
+            if (game.componentDisablePromise === operation) {
+                game.componentDisablePromise = null;
+            }
+        });
+    game.componentDisablePromise = operation;
+    return operation;
+}
+
+async function cleanupRouletteGame(game) {
+    cancelResultReveal(game);
+    await waitForRecruitmentPanelQueue(game);
+    if (!game.componentsDisabled) {
+        await scheduleComponentDisable(game);
+    }
+    await gameManager.cleanupGame(game);
+}
+
+async function fetchValidParticipants(game, participantIds) {
+    const validMembers = new Map();
+    for (const userId of participantIds) {
+        const member = await fetchMember(game, userId);
+        if (isValidHumanMember(member)) validMembers.set(userId, member);
+    }
+    return validMembers;
+}
+
+async function applyTimeouts(game, outcome, members) {
+    const failedIds = [];
+    for (const userId of outcome.selectedIds) {
+        const member = members.get(userId);
+        if (!member?.moderatable || typeof member.timeout !== 'function') {
+            failedIds.push(userId);
+            continue;
+        }
+        try {
+            await member.timeout(ROULETTE_TIMEOUT_DURATION_MS, ROULETTE_TIMEOUT_REASON);
+        } catch (error) {
+            failedIds.push(userId);
+            logDiscordFailure(game, 'timeout-member', error, userId);
+        }
+    }
+    return failedIds;
+}
+
+async function claimSettlement(game) {
+    while (true) {
+        const observedPanelVersion = game.recruitmentPanelVersion || 0;
+        await waitForRecruitmentPanelQueue(game);
+
+        let ownsSettlement = false;
+        let panelQueueAdvanced = false;
+        await gameManager.runExclusive(game, () => {
+            if (game.ended || game.state !== 'recruiting') return;
+            if ((game.recruitmentPanelVersion || 0) !== observedPanelVersion) {
+                panelQueueAdvanced = true;
+                return;
+            }
+            if (game.pendingJoins > 0) {
+                game.startRequested = true;
+                return;
+            }
+
+            game.state = 'starting';
+            ownsSettlement = true;
+            if (game.recruitmentTimer) {
+                clearTimeout(game.recruitmentTimer);
+                game.timers.delete(game.recruitmentTimer);
+                game.recruitmentTimer = null;
+            }
+        });
+        if (!panelQueueAdvanced) return ownsSettlement;
+    }
+}
+
+async function settleClaimedGame(game) {
+    await scheduleComponentDisable(game);
+
+    const participantSnapshot = [...game.participantIds];
+    const fetchedMembers = await fetchValidParticipants(game, participantSnapshot);
+    let decision = null;
+    await gameManager.runExclusive(game, () => {
+        if (game.ended || game.state !== 'starting' || game.resolved) return;
+
+        for (const userId of participantSnapshot) {
+            if (game.participantIds.includes(userId) && !fetchedMembers.has(userId)) {
+                gameManager.removePlayer(game, userId);
+            }
+        }
+
+        const participantIds = game.participantIds.filter(userId => fetchedMembers.has(userId));
+        if (participantIds.length < MIN_PARTICIPANTS) {
+            game.state = 'ended';
+            decision = { cancelled: true };
+            return;
+        }
+
+        decision = { cancelled: false, participantIds };
+    });
+
+    if (!decision) return;
+    if (decision.cancelled) {
+        const cancellationUpdated = await editPublicPanel(game, {
+            embeds: [makeEmbed(cancellationDescription())],
+            components: [joinRow(game.id, true)],
+        }, 'cancel-panel');
+        if (cancellationUpdated) game.componentsDisabled = true;
+    } else {
+        let publishedParticipantIds = decision.participantIds;
+        const startingMessage = await sendPublicPanel(game, {
+            embeds: [makeEmbed(startingDescription(publishedParticipantIds))],
+            components: [],
+        }, 'starting-panel');
+        if (!startingMessage) {
+            await cleanupRouletteGame(game);
+            return;
+        }
+        if (!await waitForResultReveal(game)) {
+            await cleanupRouletteGame(game);
+            return;
+        }
+
+        let outcome = null;
+        let cancelledDuringPublish = false;
+        let settlementAborted = false;
+        while (!outcome && !cancelledDuringPublish && !settlementAborted) {
+            let refreshedParticipantIds = null;
+            await gameManager.runExclusive(game, () => {
+                if (game.ended || game.state !== 'starting' || game.resolved) {
+                    settlementAborted = true;
+                    return;
+                }
+                const currentParticipantIds = game.participantIds.filter(
+                    userId => fetchedMembers.has(userId)
+                );
+                if (currentParticipantIds.length < MIN_PARTICIPANTS) {
+                    game.state = 'ended';
+                    cancelledDuringPublish = true;
+                    return;
+                }
+                if (
+                    currentParticipantIds.length !== publishedParticipantIds.length
+                    || currentParticipantIds.some(
+                        (userId, index) => userId !== publishedParticipantIds[index]
+                    )
+                ) {
+                    refreshedParticipantIds = currentParticipantIds;
+                    return;
+                }
+
+                outcome = drawRouletteOutcome(currentParticipantIds, game.random);
+                game.outcome = outcome;
+                game.resolved = true;
+                game.state = 'ended';
+            });
+
+            if (refreshedParticipantIds) {
+                const refreshed = await editMessage(game, startingMessage, {
+                    embeds: [makeEmbed(startingDescription(refreshedParticipantIds))],
+                    components: [],
+                }, 'refresh-starting-panel');
+                if (!refreshed) break;
+                publishedParticipantIds = refreshedParticipantIds;
+            }
+        }
+
+        if (cancelledDuringPublish) {
+            await editMessage(game, startingMessage, {
+                embeds: [makeEmbed(cancellationDescription())],
+                components: [],
+            }, 'cancel-starting-panel');
+            await cleanupRouletteGame(game);
+            return;
+        }
+        if (!outcome) {
+            await cleanupRouletteGame(game);
+            return;
+        }
+
+        const description = outcome.allWinners
+            ? allWinnersResultDescription(false)
+            : ordinaryResultDescription(outcome.selectedIds[0], false);
+        const resultMessage = await sendPublicPanel(game, {
+            embeds: [makeEmbed(description)],
+            components: [],
+        }, 'result-panel');
+        if (resultMessage) {
+            const failedIds = await applyTimeouts(game, outcome, fetchedMembers);
+            if (failedIds.length > 0) {
+                const correctedDescription = outcome.allWinners
+                    ? allWinnersResultDescription(true)
+                    : ordinaryResultDescription(outcome.selectedIds[0], true);
+                await editMessage(game, resultMessage, {
+                    embeds: [makeEmbed(correctedDescription)],
+                    components: [],
+                }, 'result-timeout-failure-panel');
+            }
+        }
+    }
+
+    await cleanupRouletteGame(game);
+}
+
+async function finishRecruitment(game) {
+    if (await claimSettlement(game)) {
+        await settleClaimedGame(game);
+    }
+}
+
+async function startRoulette(interaction) {
+    const userId = interaction.user?.id;
+    const guildId = interaction.guildId || interaction.guild?.id;
+    const channelId = interaction.channelId;
+    const provisionalGame = {
+        id: randomUUID(),
+        type: 'roulette',
+        guildId,
+        channelId,
+        channel: interaction.channel,
+        guild: interaction.guild,
+        initiatorId: userId,
+        participantIds: [userId],
+        state: 'recruiting',
+        resolved: false,
+        pendingJoins: 0,
+        startRequested: false,
+        recruitmentPanelVersion: 0,
+        recruitmentPanelCompletedVersion: 0,
+        recruitmentPanelQueue: Promise.resolve(),
+        resultRevealDelayMs: RESULT_REVEAL_DELAY_MS,
+        random: Math.random,
+        timers: new Set(),
+    };
+
+    if (!await deferReply(interaction, undefined, provisionalGame, 'defer-recruitment')) {
+        return false;
+    }
+
+    const member = await fetchMember(provisionalGame, userId);
+    if (!member?.id || !member.user || member.user.bot) {
+        await replacePublicDeferWithEphemeral(interaction, INVALID_MEMBER_MESSAGE, provisionalGame);
+        return false;
+    }
+    if (isActivelyTimedOut(member)) {
+        await replacePublicDeferWithEphemeral(interaction, TIMEOUT_BLOCKED_MESSAGE, provisionalGame);
+        return false;
+    }
+
+    let game;
+    provisionalGame.onMemberInvalidated = async invalidMember => {
+        const invalidUserId = invalidMember?.id || invalidMember?.user?.id;
+        if (invalidUserId) {
+            await handleRouletteMemberInvalidated(game, invalidUserId, 'member-invalidated');
+        }
+    };
+    provisionalGame.disableComponents = () => {
+        cancelResultReveal(game);
+        void scheduleComponentDisable(game);
+    };
+
+    const created = gameManager.createGame(provisionalGame);
+    if (!created.ok) {
+        await replacePublicDeferWithEphemeral(
+            interaction,
+            created.reason === 'player' ? PLAYER_BUSY_MESSAGE : CHANNEL_BUSY_MESSAGE,
+            provisionalGame
+        );
+        return false;
+    }
+    game = created.game;
+
+    try {
+        const replyResult = await interaction.editReply(recruitmentPayload(game));
+        const replyMessage = replyResult?.resource?.message || replyResult;
+        if (typeof replyMessage?.edit === 'function') {
+            game.message = replyMessage;
+        } else if (typeof interaction.editReply === 'function') {
+            game.message = { edit: payload => interaction.editReply(payload) };
+        }
+    } catch (error) {
+        logDiscordFailure(game, 'recruitment-panel', error, userId);
+        await cleanupRouletteGame(game);
+        await replacePublicDeferWithEphemeral(interaction, JOIN_FAILURE_MESSAGE, game);
+        return false;
+    }
+
+    try {
+        const fetchedReply = await interaction.fetchReply();
+        if (typeof fetchedReply?.edit === 'function') game.message = fetchedReply;
+    } catch (error) {
+        logDiscordFailure(game, 'fetch-recruitment-panel', error, userId);
+        if (!game.message) {
+            await cleanupRouletteGame(game);
+            return false;
+        }
+    }
+
+    game.recruitmentTimer = setTimeout(
+        () => finishRecruitment(game).catch(error => logDiscordFailure(game, 'recruitment-timer', error)),
+        RECRUITMENT_DURATION_MS
+    );
+    game.timers.add(game.recruitmentTimer);
+    return true;
+}
+
+function parseJoinParts(parts) {
+    const tokens = (Array.isArray(parts) ? parts : [parts])
+        .filter(part => typeof part === 'string')
+        .flatMap(part => part.split(/[:_]/))
+        .filter(Boolean)
+        .filter(part => part !== 'mystery' && part !== 'roulette');
+    const actionIndex = tokens.indexOf('join');
+    if (actionIndex === -1) return null;
+    return tokens[actionIndex + 1] || tokens.at(-1);
+}
+
+async function handleRouletteInteraction(interaction, parts) {
+    if (!await deferReply(
+        interaction,
+        { flags: MessageFlags.Ephemeral },
+        null,
+        'defer-join'
+    )) {
+        return false;
+    }
+
+    const gameId = parseJoinParts(parts);
+    const game = gameId && gameManager.getGame(gameId);
+    if (!game || game.type !== 'roulette') {
+        await safeDeferredReplyEdit(interaction, EXPIRED_MESSAGE, game);
+        return false;
+    }
+
+    const userId = interaction.user?.id;
+    let rejectionMessage = null;
+    const inspectJoinState = () => {
+        if (
+            game.ended
+            || game.state !== 'recruiting'
+            || interaction.channelId !== game.channelId
+            || (interaction.guildId || interaction.guild?.id) !== game.guildId
+        ) {
+            return EXPIRED_MESSAGE;
+        }
+        if (game.participantIds.includes(userId)) {
+            return DUPLICATE_MESSAGE;
+        }
+        if (game.participantIds.length >= MAX_PARTICIPANTS) {
+            return FULL_MESSAGE;
+        }
+        return null;
+    };
+
+    await gameManager.runExclusive(game, () => {
+        rejectionMessage = inspectJoinState();
+    });
+    if (rejectionMessage) {
+        await safeDeferredReplyEdit(interaction, rejectionMessage, game);
+        return false;
+    }
+
+    const member = await fetchMember(game, userId);
+    if (!member?.id || !member.user || member.user.bot) {
+        await safeDeferredReplyEdit(interaction, INVALID_MEMBER_MESSAGE, game);
+        return false;
+    }
+    if (isActivelyTimedOut(member)) {
+        await safeDeferredReplyEdit(interaction, TIMEOUT_BLOCKED_MESSAGE, game);
+        return false;
+    }
+
+    let joinCommitted = false;
+    await gameManager.runExclusive(game, () => {
+        rejectionMessage = inspectJoinState();
+        if (rejectionMessage) return;
+        if (isActivelyTimedOut(member)) {
+            rejectionMessage = TIMEOUT_BLOCKED_MESSAGE;
+            return;
+        }
+        const ownedGame = gameManager.getPlayerGame(game.guildId, userId);
+        if (ownedGame && ownedGame !== game) {
+            rejectionMessage = PLAYER_BUSY_MESSAGE;
+            return;
+        }
+        if (!gameManager.addPlayer(game, userId)) {
+            rejectionMessage = PLAYER_BUSY_MESSAGE;
+            return;
+        }
+        game.pendingJoins += 1;
+        joinCommitted = true;
+    });
+    if (!joinCommitted) {
+        await safeDeferredReplyEdit(interaction, rejectionMessage || EXPIRED_MESSAGE, game);
+        return false;
+    }
+
+    let joined = false;
+    let startWhenUnlocked = false;
+    const panelResult = await queueRecruitmentPanelEdit(game, 'join-count-panel', async result => {
+        await gameManager.runExclusive(game, () => {
+            game.pendingJoins = Math.max(0, game.pendingJoins - 1);
+            if (!result.updated) {
+                gameManager.removePlayer(game, userId);
+            } else {
+                joined = !game.ended
+                    && game.state === 'recruiting'
+                    && game.participantIds.includes(userId);
+            }
+            startWhenUnlocked = game.pendingJoins === 0
+                && game.state === 'recruiting'
+                && (game.startRequested || game.participantIds.length === MAX_PARTICIPANTS);
+        });
+    });
+    const panelUpdated = panelResult.updated;
+
+    if (!panelUpdated) {
+        await safeDeferredReplyEdit(interaction, JOIN_FAILURE_MESSAGE, game);
+    } else if (!joined) {
+        await safeDeferredReplyEdit(interaction, EXPIRED_MESSAGE, game);
+    } else {
+        await safeDeferredReplyEdit(interaction, JOINED_MESSAGE, game);
+    }
+
+    if (startWhenUnlocked) {
+        await finishRecruitment(game);
+    }
+    return joined;
+}
+
+async function handleRouletteMemberInvalidated(game, userId, reason) {
+    if (!game || game.type !== 'roulette') return false;
+    let removed = false;
+    let refreshRecruitmentPanel = false;
+    await gameManager.runExclusive(game, () => {
+        if (game.ended || game.state === 'ended') return;
+        removed = gameManager.removePlayer(game, userId);
+        if (!removed) return;
+        refreshRecruitmentPanel = game.state === 'recruiting';
+    });
+    if (refreshRecruitmentPanel) {
+        await queueRecruitmentPanelEdit(game, `member-invalidated-${reason || 'unknown'}`);
+    }
+    return removed;
+}
+
+module.exports = {
+    startRoulette,
+    handleRouletteInteraction,
+    drawRouletteOutcome,
+    handleRouletteMemberInvalidated,
+};

--- a/src/modules/mystery/utils/bombCooldownStore.js
+++ b/src/modules/mystery/utils/bombCooldownStore.js
@@ -1,0 +1,200 @@
+const fs = require('node:fs/promises');
+const path = require('node:path');
+
+const COOLDOWN_DURATION_MS = 30 * 60 * 1000;
+let temporaryFileSequence = 0;
+let corruptionBackupSequence = 0;
+
+function logFailure(operation, error) {
+    console.error(`[bombCooldownStore] ${operation} failed:`, error);
+}
+
+function buildCooldownKey(guildId, userId) {
+    return `${guildId}:${userId}`;
+}
+
+function createBombCooldownStore({ filePath, now = Date.now }) {
+    let cooldowns = {};
+    let writeQueue = Promise.resolve();
+
+    async function ensureDirectory() {
+        try {
+            await fs.mkdir(path.dirname(filePath), { recursive: true });
+            return true;
+        } catch (error) {
+            logFailure('creating cooldown directory', error);
+            return false;
+        }
+    }
+
+    async function writeSnapshot(snapshot) {
+        if (!await ensureDirectory()) {
+            return;
+        }
+
+        const temporaryPath = `${filePath}.${process.pid}.${Date.now()}.${temporaryFileSequence++}.tmp`;
+        try {
+            await fs.writeFile(temporaryPath, JSON.stringify(snapshot), 'utf8');
+        } catch (error) {
+            logFailure('writing temporary cooldown file', error);
+            try {
+                await fs.unlink(temporaryPath);
+            } catch (cleanupError) {
+                if (cleanupError.code !== 'ENOENT') {
+                    logFailure('cleaning up temporary cooldown file', cleanupError);
+                }
+            }
+            return;
+        }
+
+        try {
+            await fs.rename(temporaryPath, filePath);
+        } catch (error) {
+            logFailure('renaming temporary cooldown file', error);
+            try {
+                await fs.unlink(temporaryPath);
+            } catch (cleanupError) {
+                if (cleanupError.code !== 'ENOENT') {
+                    logFailure('cleaning up temporary cooldown file', cleanupError);
+                }
+            }
+        }
+    }
+
+    function queueWrite() {
+        const snapshot = { ...cooldowns };
+        writeQueue = writeQueue.then(
+            () => writeSnapshot(snapshot),
+            (error) => {
+                logFailure('waiting for queued cooldown write', error);
+                return writeSnapshot(snapshot);
+            },
+        );
+        return writeQueue;
+    }
+
+    function removeExpiredCooldowns() {
+        const currentTime = now();
+        let removed = false;
+
+        for (const [key, expiresAt] of Object.entries(cooldowns)) {
+            if (!Number.isFinite(expiresAt) || expiresAt <= currentTime) {
+                delete cooldowns[key];
+                removed = true;
+            }
+        }
+
+        return removed;
+    }
+
+    async function backupMalformedFile() {
+        const parsedPath = path.parse(filePath);
+        const backupId = (Date.now() * 1000) + (corruptionBackupSequence++ % 1000);
+        const backupPath = path.join(parsedPath.dir, `${parsedPath.name}.corrupt-${backupId}${parsedPath.ext}`);
+
+        try {
+            await fs.rename(filePath, backupPath);
+            return true;
+        } catch (error) {
+            logFailure('backing up malformed cooldown file', error);
+            return false;
+        }
+    }
+
+    async function load() {
+        try {
+            await writeQueue;
+        } catch (error) {
+            logFailure('waiting before cooldown load', error);
+        }
+
+        if (!await ensureDirectory()) {
+            cooldowns = {};
+            return;
+        }
+
+        let parsedCooldowns = {};
+        let shouldWrite = false;
+
+        let serializedCooldowns;
+        try {
+            serializedCooldowns = await fs.readFile(filePath, 'utf8');
+        } catch (error) {
+            if (error.code === 'ENOENT') {
+                shouldWrite = true;
+            } else {
+                logFailure('reading cooldown file', error);
+            }
+        }
+
+        if (serializedCooldowns !== undefined) {
+            try {
+                const value = JSON.parse(serializedCooldowns);
+                if (!value || Array.isArray(value) || typeof value !== 'object') {
+                    throw new Error('Cooldown data must be a JSON object');
+                }
+                parsedCooldowns = value;
+            } catch (error) {
+                logFailure('reading cooldown file', error);
+                shouldWrite = await backupMalformedFile();
+            }
+        }
+
+        cooldowns = parsedCooldowns;
+        if (removeExpiredCooldowns()) {
+            shouldWrite = true;
+        }
+
+        if (shouldWrite) {
+            await queueWrite();
+        }
+    }
+
+    function isOnCooldown(guildId, userId) {
+        const key = buildCooldownKey(guildId, userId);
+        const expiresAt = cooldowns[key];
+
+        if (!Number.isFinite(expiresAt) || expiresAt <= now()) {
+            if (Object.hasOwn(cooldowns, key)) {
+                delete cooldowns[key];
+                void queueWrite();
+            }
+            return false;
+        }
+
+        return true;
+    }
+
+    function startCooldown(guildId, userId) {
+        cooldowns[buildCooldownKey(guildId, userId)] = now() + COOLDOWN_DURATION_MS;
+        void queueWrite();
+    }
+
+    async function flush() {
+        try {
+            await writeQueue;
+        } catch (error) {
+            logFailure('flushing cooldown writes', error);
+        }
+    }
+
+    return {
+        isOnCooldown,
+        startCooldown,
+        load,
+        flush,
+    };
+}
+
+const defaultStore = createBombCooldownStore({
+    filePath: path.join('data', 'mystery', 'bombCooldowns.json'),
+});
+
+module.exports = {
+    COOLDOWN_DURATION_MS,
+    createBombCooldownStore,
+    isOnCooldown: defaultStore.isOnCooldown,
+    startCooldown: defaultStore.startCooldown,
+    load: defaultStore.load,
+    flush: defaultStore.flush,
+};

--- a/src/modules/safetySetup/commands/closeDoor.js
+++ b/src/modules/safetySetup/commands/closeDoor.js
@@ -18,10 +18,10 @@ const data = new SlashCommandBuilder()
     .setDescription('暂停服务器邀请并交由 Bot 自动续期托管')
     .addStringOption((option) => option
         .setName('恢复时间')
-        .setDescription('可选，北京时间 YYYY-MM-DD HH:mm；不填则仅 /开门 才恢复')
+        .setDescription('可选，北京时间 YYYY-MM-DD HH:mm；不填则仅 /管理 开门 才恢复')
         .setRequired(false));
 
-async function execute(interaction) {
+async function executeCloseDoor(interaction) {
     if (!interaction.inGuild()) {
         return interaction.reply({
             content: '❌ 此命令只能在服务器中使用。',
@@ -73,7 +73,7 @@ async function execute(interaction) {
         const discordUntilTimestamp = Math.floor(invitesDisabledUntil.getTime() / 1000);
         const modeText = resumeAt
             ? `预约在 **${formatBeijingDateTime(resumeAt)}（北京时间）** 自动恢复邀请。`
-            : '已启用无限期托管，直到执行 `/开门` 才恢复邀请。';
+            : '已启用无限期托管，直到执行 `/管理 开门` 才恢复邀请。';
 
         return interaction.editReply({
             content: [
@@ -85,11 +85,15 @@ async function execute(interaction) {
             ].join('\n'),
         });
     } catch (error) {
-        console.error(`[SafetySetup] /关门 执行失败 (guild=${interaction.guild.id}):`, error);
+        console.error(`[SafetySetup] /管理 关门 执行失败 (guild=${interaction.guild.id}):`, error);
         return interaction.editReply({
             content: `❌ 暂停邀请失败，未启用自动托管：${error.message}`,
         });
     }
 }
 
-module.exports = { data, execute };
+module.exports = {
+    data,
+    execute: executeCloseDoor,
+    executeCloseDoor,
+};

--- a/src/modules/safetySetup/commands/openDoor.js
+++ b/src/modules/safetySetup/commands/openDoor.js
@@ -16,7 +16,7 @@ const data = new SlashCommandBuilder()
     .setName('开门')
     .setDescription('停止邀请暂停托管并恢复服务器邀请');
 
-async function execute(interaction) {
+async function executeOpenDoor(interaction) {
     if (!interaction.inGuild()) {
         return interaction.reply({
             content: '❌ 此命令只能在服务器中使用。',
@@ -44,7 +44,7 @@ async function execute(interaction) {
                 content: `⚠️ Bot 缺少“管理服务器（Manage Guild）”权限，无法立即恢复邀请。${state}`,
             });
         } catch (error) {
-            console.error(`[SafetySetup] /开门 停止托管失败 (guild=${guildId}):`, error);
+            console.error(`[SafetySetup] /管理 开门 停止托管失败 (guild=${guildId}):`, error);
             return interaction.editReply({
                 content: `❌ Bot 缺少“管理服务器（Manage Guild）”权限，且无法确认自动托管是否已停止：${error.message}`,
             });
@@ -67,7 +67,7 @@ async function execute(interaction) {
             content: '🔓 **已开门：自动托管已停止，服务器邀请已恢复。**',
         });
     } catch (error) {
-        console.error(`[SafetySetup] /开门 执行失败 (guild=${guildId}):`, error);
+        console.error(`[SafetySetup] /管理 开门 执行失败 (guild=${guildId}):`, error);
         return interaction.editReply({
             content: [
                 '⚠️ 自动托管已停止，但 Discord 恢复邀请失败。',
@@ -78,4 +78,8 @@ async function execute(interaction) {
     }
 }
 
-module.exports = { data, execute };
+module.exports = {
+    data,
+    execute: executeOpenDoor,
+    executeOpenDoor,
+};


### PR DESCRIPTION
本 PR 扩展神秘指令娱乐系统，并统一相关管理入口。

### 新增多人神秘游戏

新增：

- `/神秘指令 运气轮盘`
- `/神秘指令 传炸弹`
- `/神秘指令 死斗`

新增多人游戏共享状态管理，包括：

- 玩家游戏占用
- 当前频道游戏占用
- 游戏状态管理
- Component Interaction
- Timeout 娱乐效果
- 游戏正常结束与异常中止清理

### 运气轮盘

支持 3～6 人参与，包含报名、自动开局、随机结果及游戏 Timeout 结算。

### 传炸弹

支持 3～8 人参与，包含隐藏爆炸时间、玩家传递、持有者状态以及爆炸结算。

传炸弹发起冷却通过独立运行时 JSON 持久化，Bot 重启后仍会保留未过期冷却。

### 死斗

新增双人石头剪刀布玩法。

支持：

- 指定对手
- 公开挑战
- 秘密出拳
- 回合超时
- 比分结算
- 三局两胜
- 败者娱乐 Timeout

### 神秘名字库

新增：

- `/管理 神秘名字库`

支持：

- 批量添加
- 可视化多选删除
- 批量删除
- 分页查看

名字库全 Bot 共用，并通过独立 JSON 持久化。

`/神秘指令 取名字好麻烦` 现在会实时使用管理员维护后的名字库。

原默认名字仍作为首次初始化数据保留。

### 管理命令统一

原：

- `/关门`
- `/开门`

迁移为：

- `/管理 关门`
- `/管理 开门`

最终 `/管理` 包含：

- 神秘名字库
- 关门
- 开门

原 SafetySetup 业务逻辑及权限检查保持不变。

## 兼容性

- `/神秘指令 自刎归天` 原功能保持
- `/神秘指令 取名字好麻烦` 原 cooldown 和昵称修改行为保持
- 未新增正式处罚记录
- 未修改数据库
- 未新增 npm 依赖
- 未修改 `package.json` / `package-lock.json`

## 数据

运行时 JSON 已加入 `.gitignore`，不会进入 Git。

包括：

- 神秘名字库
- 传炸弹冷却数据

多人游戏进行状态仅存在内存中，Bot 重启不会恢复未完成游戏。
