### PR TITLE
feat(mystery): 子区主可在子区内禁用/启用神秘指令

### DIFF
--- a/src/core/index.js
+++ b/src/core/index.js
@@ -1,11 +1,30 @@
 // src/core/index.js
 require('dotenv').config();
+
+// --- 进程级兖底日志（避免“Discord 无响应但控制台无日志”难以排查） ---
+// 可选：设置 FATAL_EXIT_ON_EXCEPTION=true，在发生 uncaughtException 时直接退出（建议配合进程守护工具使用）。
 const FATAL_EXIT_ON_EXCEPTION = String(process.env.FATAL_EXIT_ON_EXCEPTION || '').toLowerCase() === 'true';
-process.on('unhandledRejection', (reason) => { console.error('\u274c [Process] unhandledRejection:', reason); });
-process.on('uncaughtException', (err) => { console.error('\u274c [Process] uncaughtException:', err); if (FATAL_EXIT_ON_EXCEPTION) { process.exit(1); } });
-const { Client, Collection, Events, GatewayIntentBits } = require('discord.js');
-const { clientReadyHandler } = require('./events/clientReady');
-const { interactionCreateHandler } = require('./events/interactionCreate');
+
+process.on('unhandledRejection', (reason) => {
+    console.error('❌ [Process] unhandledRejection:', reason);
+});
+
+process.on('uncaughtException', (err) => {
+    console.error('❌ [Process] uncaughtException:', err);
+    if (FATAL_EXIT_ON_EXCEPTION) {
+        process.exit(1);
+    }
+});
+
+const {
+    Client,
+    Collection,
+    Events, 
+    GatewayIntentBits,
+} = require('discord.js')
+
+const { clientReadyHandler } = require('./events/clientReady')
+const { interactionCreateHandler } = require('./events/interactionCreate')
 const { startProposalChecker } = require('../modules/proposal/services/proposalChecker');
 const { startCourtChecker } = require('../modules/court/services/courtChecker');
 const { startSelfModerationChecker } = require('../modules/selfModeration/services/moderationChecker');
@@ -17,9 +36,22 @@ const { syncMissedActivity } = require('../modules/selfRole/services/autoSyncSer
 const { startSelfRoleApplicationChecker } = require('../modules/selfRole/services/applicationChecker');
 const { startSelfRoleLifecycleScheduler } = require('../modules/selfRole/services/lifecycleScheduler');
 const { startSelfRoleConsistencyChecker } = require('../modules/selfRole/services/consistencyChecker');
-const { startRoleSyncSystem, roleSyncGuildMemberAddHandler, roleSyncGuildMemberRemoveHandler, roleSyncGuildMemberUpdateHandler, roleSyncGuildRoleDeleteHandler } = require('../modules/roleSync');
+
+// 身份组同步系统（多服务器）
+const {
+    startRoleSyncSystem,
+    roleSyncGuildMemberAddHandler,
+    roleSyncGuildMemberRemoveHandler,
+    roleSyncGuildMemberUpdateHandler,
+    roleSyncGuildRoleDeleteHandler,
+} = require('../modules/roleSync');
+
+// 导入命令
 const pingCommand = require('../shared/commands/ping');
+// const debugPermissionsCommand = require('../shared/commands/debugPermissions');  // 需要使用再取消注释
 const setCheckChannelCommand = require('../shared/commands/setCheckChannel');
+
+// 提案系统命令
 const setupFormCommand = require('../modules/proposal/commands/setupForm');
 const deleteEntryCommand = require('../modules/proposal/commands/deleteEntry');
 const withdrawProposalCommand = require('../modules/proposal/commands/withdrawProposal');
@@ -27,15 +59,24 @@ const setFormPermissionsCommand = require('../modules/proposal/commands/setFormP
 const setSupportPermissionsCommand = require('../modules/proposal/commands/setSupportPermissions');
 const reviewProposalCommand = require('../modules/proposal/commands/reviewProposal');
 const setProposalReviewersCommand = require('../modules/proposal/commands/setProposalReviewers');
+
+// 审核系统命令（已合并为 /创作者审核）
 const creatorReviewCommand = require('../modules/creatorReview/commands/creatorReview');
+
+// 法庭系统命令
 const setAllowCourtRoleCommand = require('../modules/court/commands/setAllowCourtRole');
 const applyToCourtCommand = require('../modules/court/commands/applyToCourt');
+
+// 自助管理系统命令
 const deleteShitMessageCommand = require('../modules/selfModeration/commands/deleteShitMessage');
 const muteShitUserCommand = require('../modules/selfModeration/commands/muteShitUser');
 const seriousMuteCommand = require('../modules/selfModeration/commands/seriousMute');
+// 8 个配置指令已合并为 /搬石公投配置
 const selfModerationConfigCommand = require('../modules/selfModeration/commands/selfModerationConfig');
 const checkMyCooldownCommand = require('../modules/selfModeration/commands/checkMyCooldown');
 const getArchiveViewPermissionCommand = require('../modules/selfModeration/commands/getArchiveViewPermission');
+
+// 赛事系统命令
 const setupContestApplicationCommand = require('../modules/contest/commands/setupContestApplication');
 const manageTrackCommand = require('../modules/contest/commands/manageTrack');
 const setContestReviewersCommand = require('../modules/contest/commands/setContestReviewers');
@@ -57,23 +98,35 @@ const syncTournamentCommand = require('../modules/contest/commands/syncTournamen
 const deleteTournamentCommand = require('../modules/contest/commands/deleteTournament');
 const listBooklistsCommand = require('../modules/contest/commands/listBooklists');
 const manageSyncExclusionCommand = require('../modules/contest/commands/manageSyncExclusion');
+
+// 自动清理系统命令（合并后）
 const keywordManagerCommand = require('../modules/autoCleanup/commands/keywordManager');
 const exemptManagerCommand = require('../modules/autoCleanup/commands/exemptManager');
 const cleanupManagerCommand = require('../modules/autoCleanup/commands/cleanupManager');
+
+// 频道总结系统命令
 const summarizeChannelCommand = require('../modules/channelSummary/commands/summarizeChannel');
 const summaryPresetCommand = require('../modules/channelSummary/commands/summaryPreset');
+
+// 投票系统命令
 const createVoteCommand = require('../modules/voting/commands/createVote');
+// 添加新的通知身份组命令
 const notificationRolesCommand = require('../modules/voting/commands/notificationRoles');
+
 const { messageCreateHandler } = require('./events/messageCreate');
+
+// 自助文件上传系统命令
 const uploadCommand = require('../modules/selfFileUpload/commands/uploadFile');
 const whoisCommand = require('../modules/selfFileUpload/commands/queryAnonymousLog');
 const manageOptOutCommand = require('../modules/selfFileUpload/commands/manageOptOut.js');
 const collectBackupsCommand = require('../modules/selfFileUpload/commands/collectBackups.js');
+
+//// 自助身份组系统命令
 const setupRolePanelCommand = require('../modules/selfRole/commands/setupRolePanel');
 const setupAdminPanelCommand = require('../modules/selfRole/commands/setupAdminPanel');
 const recalculateActivityCommand = require('../modules/selfRole/commands/recalculateActivity');
 const checkActivityCommand = require('../modules/selfRole/commands/checkActivity');
-const debugRolesCommand = require('../modules/selfRole/commands/debugRoles');
+const debugRolesCommand = require('../modules/selfRole/commands/debugRoles'); // 调试命令
 const clearCooldownCommand = require('../modules/selfRole/commands/clearCooldown');
 const configureRolesCommand = require('../modules/selfRole/commands/configureRoles');
 const withdrawSelfRoleApplicationCommand = require('../modules/selfRole/commands/withdrawApplication');
@@ -81,44 +134,112 @@ const selfRoleOpsCommand = require('../modules/selfRole/commands/selfRoleOps');
 const selfRoleWizardCommand = require('../modules/selfRole/commands/selfRoleWizard');
 let selfRoleTestCommand = null;
 if (String(process.env.SELF_ROLE_ENABLE_TEST_COMMANDS || '').toLowerCase() === 'true') {
+    // 仅在测试环境启用（避免生产环境误注册）
     selfRoleTestCommand = require('../modules/selfRole/commands/selfRoleTest');
-    console.log('[SelfRole] test commands enabled.');
+    console.log('[SelfRole] 🧪 SELF_ROLE_ENABLE_TEST_COMMANDS=true：已启用自助身份组测试命令注册。');
 }
+
+// 身份组同步系统命令
 const roleSyncConfigCommand = require('../modules/roleSync/commands/roleSyncConfig');
+
+// 处罚系统
 const { startPunishmentSystem } = require('../modules/punishment');
 const punishCommand = require('../modules/punishment/commands/punish');
 const disciplineCommand = require('../modules/punishment/commands/discipline');
 const disciplineConfigCommand = require('../modules/punishment/commands/disciplineConfig');
+
+// 机器人消息管理系统（编辑 bot 已发出的常驻消息）
 const { startBotMessageSystem } = require('../modules/botMessage');
 const botMessageCommand = require('../modules/botMessage/commands/botMessage');
 const editBotMessageContextCommand = require('../modules/botMessage/commands/editBotMessageContext');
+
+// 分服受控邀请系统
 const { startControlledInviteSystem, controlledInviteGuildMemberAddHandler } = require('../modules/controlledInvite');
 const controlledInviteConfigCommand = require('../modules/controlledInvite/commands/controlledInviteConfig');
 const controlledInviteParamsCommand = require('../modules/controlledInvite/commands/controlledInviteParams');
 const controlledInviteToggleCommand = require('../modules/controlledInvite/commands/controlledInviteToggle');
 const viewMyControlledInviteStatusCommand = require('../modules/controlledInvite/commands/viewMyControlledInviteStatus');
+
+// Discord 安全措施（邀请暂停托管）
 const { startSafetySetupSystem } = require('../modules/safetySetup');
+
+// 神秘指令娱乐系统
 const mysteryCommand = require('../modules/mystery/commands/mysteryCommand');
 const manageCommand = require('../modules/mystery/commands/manageCommand');
 const mysteryGameStatsCommand = require('../modules/mystery/commands/gameStatsCommand');
 const mysteryToggleCommand = require('../modules/mystery/commands/mysteryToggleCommand');
 const { mysteryGuildMemberRemoveHandler } = require('../modules/mystery/events/guildMemberRemove');
 const { mysteryGuildMemberUpdateHandler } = require('../modules/mystery/events/guildMemberUpdate');
-const { handleGuildMemberUpdate: cowardPenaltyGuildMemberUpdateHandler, startCowardPenaltyRestorer } = require('../modules/mystery/services/cowardPenalty');
-const DISCORD_REST_TIMEOUT_MS = (() => { const n = Number(process.env.DISCORD_REST_TIMEOUT_MS); return Number.isFinite(n) && n > 0 ? n : 15000; })();
-const client = new Client({ intents: [GatewayIntentBits.Guilds, GatewayIntentBits.GuildMessages, GatewayIntentBits.GuildMembers, GatewayIntentBits.GuildMessageReactions, GatewayIntentBits.MessageContent], rest: { timeout: DISCORD_REST_TIMEOUT_MS } });
-client.on('error', (err) => { console.error('\u274c [Discord] client error:', err); });
-client.on('warn', (info) => { console.warn('\u26a0\ufe0f [Discord] client warn:', info); });
-client.on('shardError', (err, shardId) => { console.error(`\u274c [Discord] shardError shard=${shardId}:`, err); });
-client.on('shardDisconnect', (event, shardId) => { console.warn(`\u26a0\ufe0f [Discord] shardDisconnect shard=${shardId} code=${event?.code} reason=${event?.reason}`); });
-client.on('shardReconnecting', (shardId) => { console.warn(`\u26a0\ufe0f [Discord] shardReconnecting shard=${shardId}`); });
-client.on('shardResume', (shardId, replayedEvents) => { console.log(`\u2705 [Discord] shardResume shard=${shardId} replayed=${replayedEvents}`); });
-try { client.rest.on('rateLimited', (info) => { const route = info?.route || info?.path || 'unknown'; const method = info?.method || 'unknown'; const timeToReset = info?.timeToReset; console.warn(`\u26a0\ufe0f [Discord][REST] rateLimited ${method} ${route} resetInMs=${timeToReset}`); }); } catch (_) {}
+const {
+    handleGuildMemberUpdate: cowardPenaltyGuildMemberUpdateHandler,
+    startCowardPenaltyRestorer,
+} = require('../modules/mystery/services/cowardPenalty');
+
+const DISCORD_REST_TIMEOUT_MS = (() => {
+    const n = Number(process.env.DISCORD_REST_TIMEOUT_MS);
+    return Number.isFinite(n) && n > 0 ? n : 15000;
+})();
+
+const client = new Client({
+    intents: [
+        GatewayIntentBits.Guilds,
+        GatewayIntentBits.GuildMessages,
+        GatewayIntentBits.GuildMembers,
+        GatewayIntentBits.GuildMessageReactions, // 需要这个intent来监控reaction
+        GatewayIntentBits.MessageContent,
+    ],
+    rest: {
+        // REST 请求超时（ms）。避免网络异常时请求长时间挂起导致交互无响应。
+        timeout: DISCORD_REST_TIMEOUT_MS,
+    },
+});
+
+// --- Discord 客户端/REST 诊断日志（用于定位“无响应但无日志”） ---
+client.on('error', (err) => {
+    console.error('❌ [Discord] client error:', err);
+});
+client.on('warn', (info) => {
+    console.warn('⚠️ [Discord] client warn:', info);
+});
+client.on('shardError', (err, shardId) => {
+    console.error(`❌ [Discord] shardError shard=${shardId}:`, err);
+});
+client.on('shardDisconnect', (event, shardId) => {
+    console.warn(`⚠️ [Discord] shardDisconnect shard=${shardId} code=${event?.code} reason=${event?.reason}`);
+});
+client.on('shardReconnecting', (shardId) => {
+    console.warn(`⚠️ [Discord] shardReconnecting shard=${shardId}`);
+});
+client.on('shardResume', (shardId, replayedEvents) => {
+    console.log(`✅ [Discord] shardResume shard=${shardId} replayed=${replayedEvents}`);
+});
+
+try {
+    client.rest.on('rateLimited', (info) => {
+        const route = info?.route || info?.path || 'unknown';
+        const method = info?.method || 'unknown';
+        const timeToReset = info?.timeToReset;
+        console.warn(`⚠️ [Discord][REST] rateLimited ${method} ${route} resetInMs=${timeToReset}`);
+    });
+} catch (_) {}
+
 const HEALTH_LOG_INTERVAL_MINUTES = Number(process.env.HEALTH_LOG_INTERVAL_MINUTES || 0);
-if (Number.isFinite(HEALTH_LOG_INTERVAL_MINUTES) && HEALTH_LOG_INTERVAL_MINUTES > 0) { setInterval(() => { console.log(`[Health] wsStatus=${client.ws?.status} ping=${client.ws?.ping} guilds=${client.guilds?.cache?.size} mem=${Math.round(process.memoryUsage().rss / 1024 / 1024)}MB`); }, Math.floor(HEALTH_LOG_INTERVAL_MINUTES * 60 * 1000)); }
+if (Number.isFinite(HEALTH_LOG_INTERVAL_MINUTES) && HEALTH_LOG_INTERVAL_MINUTES > 0) {
+    setInterval(() => {
+        console.log(
+            `[Health] wsStatus=${client.ws?.status} ping=${client.ws?.ping} guilds=${client.guilds?.cache?.size} mem=${Math.round(process.memoryUsage().rss / 1024 / 1024)}MB`,
+        );
+    }, Math.floor(HEALTH_LOG_INTERVAL_MINUTES * 60 * 1000));
+}
+
 client.commands = new Collection();
+
+// 注册所有命令
 client.commands.set(pingCommand.data.name, pingCommand);
+// client.commands.set(debugPermissionsCommand.data.name, debugPermissionsCommand); // 需要使用再取消注释
 client.commands.set(setCheckChannelCommand.data.name, setCheckChannelCommand);
+
+// 提案系统命令
 client.commands.set(setupFormCommand.data.name, setupFormCommand);
 client.commands.set(deleteEntryCommand.data.name, deleteEntryCommand);
 client.commands.set(withdrawProposalCommand.data.name, withdrawProposalCommand);
@@ -126,15 +247,23 @@ client.commands.set(setFormPermissionsCommand.data.name, setFormPermissionsComma
 client.commands.set(setSupportPermissionsCommand.data.name, setSupportPermissionsCommand);
 client.commands.set(reviewProposalCommand.data.name, reviewProposalCommand);
 client.commands.set(setProposalReviewersCommand.data.name, setProposalReviewersCommand);
+
+// 审核系统命令（已合并为 /创作者审核）
 client.commands.set(creatorReviewCommand.data.name, creatorReviewCommand);
+
+// 法庭系统命令
 client.commands.set(setAllowCourtRoleCommand.data.name, setAllowCourtRoleCommand);
 client.commands.set(applyToCourtCommand.data.name, applyToCourtCommand);
+
+// 自助管理系统命令
 client.commands.set(deleteShitMessageCommand.data.name, deleteShitMessageCommand);
 client.commands.set(muteShitUserCommand.data.name, muteShitUserCommand);
 client.commands.set(seriousMuteCommand.data.name, seriousMuteCommand);
 client.commands.set(selfModerationConfigCommand.data.name, selfModerationConfigCommand);
 client.commands.set(checkMyCooldownCommand.data.name, checkMyCooldownCommand);
 client.commands.set(getArchiveViewPermissionCommand.data.name, getArchiveViewPermissionCommand);
+
+// 赛事系统命令
 client.commands.set(setupContestApplicationCommand.data.name, setupContestApplicationCommand);
 client.commands.set(manageTrackCommand.data.name, manageTrackCommand);
 client.commands.set(setContestReviewersCommand.data.name, setContestReviewersCommand);
@@ -156,66 +285,149 @@ client.commands.set(syncTournamentCommand.data.name, syncTournamentCommand);
 client.commands.set(deleteTournamentCommand.data.name, deleteTournamentCommand);
 client.commands.set(listBooklistsCommand.data.name, listBooklistsCommand);
 client.commands.set(manageSyncExclusionCommand.data.name, manageSyncExclusionCommand);
+
+// 自动清理系统命令（合并后）
 client.commands.set(keywordManagerCommand.data.name, keywordManagerCommand);
 client.commands.set(exemptManagerCommand.data.name, exemptManagerCommand);
 client.commands.set(cleanupManagerCommand.data.name, cleanupManagerCommand);
+
+// 频道总结系统命令
 client.commands.set(summarizeChannelCommand.data.name, summarizeChannelCommand);
 client.commands.set(summaryPresetCommand.data.name, summaryPresetCommand);
+
+// 投票系统命令
 client.commands.set(createVoteCommand.data.name, createVoteCommand);
+// 注册新的通知身份组命令
 client.commands.set(notificationRolesCommand.data.name, notificationRolesCommand);
+
+// 自助文件上传系统命令
 client.commands.set(uploadCommand.data.name, uploadCommand);
 client.commands.set(whoisCommand.data.name, whoisCommand);
 client.commands.set(manageOptOutCommand.data.name, manageOptOutCommand);
 client.commands.set(collectBackupsCommand.data.name, collectBackupsCommand);
+
+//// 自助身份组系统命令
 client.commands.set(setupRolePanelCommand.data.name, setupRolePanelCommand);
 client.commands.set(setupAdminPanelCommand.data.name, setupAdminPanelCommand);
 client.commands.set(recalculateActivityCommand.data.name, recalculateActivityCommand);
 client.commands.set(checkActivityCommand.data.name, checkActivityCommand);
-client.commands.set(debugRolesCommand.data.name, debugRolesCommand);
+client.commands.set(debugRolesCommand.data.name, debugRolesCommand); // 调试命令
 client.commands.set(clearCooldownCommand.data.name, clearCooldownCommand);
 client.commands.set(configureRolesCommand.data.name, configureRolesCommand);
 client.commands.set(withdrawSelfRoleApplicationCommand.data.name, withdrawSelfRoleApplicationCommand);
 client.commands.set(selfRoleOpsCommand.data.name, selfRoleOpsCommand);
 client.commands.set(selfRoleWizardCommand.data.name, selfRoleWizardCommand);
-if (selfRoleTestCommand) { client.commands.set(selfRoleTestCommand.data.name, selfRoleTestCommand); }
+if (selfRoleTestCommand) {
+    client.commands.set(selfRoleTestCommand.data.name, selfRoleTestCommand);
+}
 client.commands.set(roleSyncConfigCommand.data.name, roleSyncConfigCommand);
+
+// 处罚系统命令
 client.commands.set(punishCommand.data.name, punishCommand);
 client.commands.set(disciplineCommand.data.name, disciplineCommand);
 client.commands.set(disciplineConfigCommand.data.name, disciplineConfigCommand);
+
+// 机器人消息管理系统命令
 client.commands.set(botMessageCommand.data.name, botMessageCommand);
 client.commands.set(editBotMessageContextCommand.data.name, editBotMessageContextCommand);
+
+// 分服受控邀请系统命令
 client.commands.set(controlledInviteConfigCommand.data.name, controlledInviteConfigCommand);
 client.commands.set(controlledInviteParamsCommand.data.name, controlledInviteParamsCommand);
 client.commands.set(controlledInviteToggleCommand.data.name, controlledInviteToggleCommand);
 client.commands.set(viewMyControlledInviteStatusCommand.data.name, viewMyControlledInviteStatusCommand);
+
+// Discord 安全措施与神秘管理工具（统一为唯一 /管理）
 client.commands.set(manageCommand.data.name, manageCommand);
+
+// 神秘指令娱乐系统
 client.commands.set(mysteryCommand.data.name, mysteryCommand);
 client.commands.set(mysteryGameStatsCommand.data.name, mysteryGameStatsCommand);
 client.commands.set(mysteryToggleCommand.data.name, mysteryToggleCommand);
-if (String(process.env.MYSTERY_TEST_COMMANDS).toLowerCase() === 'true') { const pressureTestCommand = require('../modules/mystery/commands/pressureTestCommand'); client.commands.set(pressureTestCommand.data.name, pressureTestCommand); console.log('test mystery commands registered'); }
+
+// 加压轮盘测试指令：仅在 .env 里设置 MYSTERY_TEST_COMMANDS=true 时才注册，
+// 避免测试用的虚拟机器人局出现在正式服务器的指令列表里。
+if (String(process.env.MYSTERY_TEST_COMMANDS).toLowerCase() === 'true') {
+    const pressureTestCommand = require('../modules/mystery/commands/pressureTestCommand');
+    client.commands.set(pressureTestCommand.data.name, pressureTestCommand);
+    console.log('🧪 加压轮盘测试指令已注册（MYSTERY_TEST_COMMANDS=true）');
+}
+
 client.once(Events.ClientReady, async (readyClient) => {
-    try { await clientReadyHandler(readyClient); } catch (err) { console.error('\u274c startup command sync failed:', err); try { readyClient.destroy(); } catch (_) {} process.exit(1); return; }
+    try {
+        // 启动时强制同步命令（clientReadyHandler 内部会执行 rest.put 刷新命令）
+        // 若开启 STRICT_COMMAND_SYNC=true 且存在失败 guild，将直接抛错并中止启动。
+        await clientReadyHandler(readyClient);
+    } catch (err) {
+        console.error('❌ 启动阶段命令同步失败，进程即将退出：', err);
+        try {
+            readyClient.destroy();
+        } catch (_) {}
+        process.exit(1);
+        return;
+    }
     printTimeConfig();
-    startProposalChecker(readyClient); console.log('\u2705 proposal checker started');
-    startCourtChecker(readyClient); console.log('\u2705 court checker started');
-    startSelfModerationChecker(readyClient); console.log('\u2705 self-moderation checker started');
-    startAttachmentCleanupScheduler(readyClient); console.log('\u2705 attachment cleanup scheduler started');
-    startVoteChecker(readyClient); console.log('\u2705 vote checker started');
-    console.log('\u2705 auto cleanup system started');
+    
+    startProposalChecker(readyClient);
+    console.log('✅ 提案检查器已启动');
+    
+    startCourtChecker(readyClient);
+    console.log('✅ 法庭系统检查器已启动');
+    
+    startSelfModerationChecker(readyClient);
+    console.log('✅ 自助管理检查器已启动');
+    
+    startAttachmentCleanupScheduler(readyClient);
+    console.log('✅ 附件清理定时器已启动');
+    
+    startVoteChecker(readyClient);
+    console.log('✅ 投票检查器已启动');
+    
+    // 初始化自动清理系统
+    console.log('✅ 自动清理系统已启动');
+
     startActivityTracker();
-    await startCowardPenaltyRestorer(readyClient); console.log('\u2705 coward penalty restorer done');
+
+    // 恢复未结束的「胆小鬼」昵称惩罚，避免重启后 🤡 前缀永久卡在别人名字上
+    await startCowardPenaltyRestorer(readyClient);
+    console.log('✅ 胆小鬼惩罚恢复完成');
+
+    // SelfRole 申请过期检查器（预留名额释放/旧数据兼容迁移）
     startSelfRoleApplicationChecker(readyClient);
+    
+    // 在机器人完全启动前，执行离线数据同步
     await syncMissedActivity(readyClient);
+
+    // SelfRole grant 生命周期调度器（周期询问/onlyWhenFull/强制清退）
     startSelfRoleLifecycleScheduler(readyClient);
+
+    // SelfRole 一致性巡检（grant/面板/角色残留等）
     startSelfRoleConsistencyChecker(readyClient);
+
+    // 启动身份组同步系统
     await startRoleSyncSystem(readyClient);
+
+    // 启动处罚系统
     await startPunishmentSystem(readyClient);
+
+    // 启动机器人消息管理系统
     await startBotMessageSystem(readyClient);
+
+    // 启动分服受控邀请系统
     await startControlledInviteSystem(readyClient);
+
+    // 启动 Discord 安全措施邀请暂停托管
     await startSafetySetupSystem(readyClient);
-    console.log('\n\ud83e\udd16 Bot fully started, all systems operational!');
-});
-client.on(Events.InteractionCreate, interactionCreateHandler);
+
+    console.log('\n🤖 机器人已完全启动，所有系统正常运行！');
+    console.log('🏆 赛事管理系统已加载');
+    console.log('🧹 自动消息清理系统已加载');
+    console.log('📝 机器人消息管理系统已加载');
+})
+
+client.on(Events.InteractionCreate, interactionCreateHandler)
+
+// 添加消息创建事件处理器
 client.on(Events.MessageCreate, messageCreateHandler);
 client.on(Events.GuildMemberAdd, roleSyncGuildMemberAddHandler);
 client.on(Events.GuildMemberAdd, controlledInviteGuildMemberAddHandler);
@@ -225,9 +437,31 @@ client.on(Events.GuildRoleDelete, roleSyncGuildRoleDeleteHandler);
 client.on(Events.GuildMemberRemove, mysteryGuildMemberRemoveHandler);
 client.on(Events.GuildMemberUpdate, mysteryGuildMemberUpdateHandler);
 client.on(Events.GuildMemberUpdate, cowardPenaltyGuildMemberUpdateHandler);
-function normalizeDiscordToken(raw) { if (!raw) return ''; let token = String(raw).trim(); if (!token) return ''; token = token.replace(/^Bot\s+/i, '').trim(); return token; }
+
+function normalizeDiscordToken(raw) {
+    if (!raw) return '';
+    let token = String(raw).trim();
+    if (!token) return '';
+    // 兼容误填 "Bot <token>"
+    token = token.replace(/^Bot\s+/i, '').trim();
+    return token;
+}
+
 const token = normalizeDiscordToken(process.env.DISCORD_TOKEN);
-if (!token || token.includes('PASTE_YOUR_DISCORD_BOT_TOKEN')) { console.error('\u274c Missing DISCORD_TOKEN'); process.exit(1); }
-if (token.split('.').length !== 3) { console.error('\u274c DISCORD_TOKEN format error'); process.exit(1); }
+if (!token || token.includes('PASTE_YOUR_DISCORD_BOT_TOKEN')) {
+    console.error('❌ 缺少或未正确配置 DISCORD_TOKEN。请在项目根目录 .env 中设置 DISCORD_TOKEN=你的机器人Token 后重启。');
+    process.exit(1);
+}
+if (token.split('.').length !== 3) {
+    console.error('❌ DISCORD_TOKEN 格式异常：应为 3 段以英文点号分隔的 token。请检查是否有空格/换行/前缀 Bot 等。');
+    process.exit(1);
+}
+
+// 确保后续模块（如命令同步）拿到的是清洗后的 token
 process.env.DISCORD_TOKEN = token;
-client.login(token).catch((err) => { console.error('\u274c Discord login failed:', err); process.exit(1); });
+
+client.login(token).catch((err) => {
+    console.error('❌ Discord 登录失败。常见原因：Token 粘贴错误 / Token 已被重置失效 / 使用了非 Bot Token。');
+    console.error(err);
+    process.exit(1);
+});

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -1,30 +1,11 @@
 // src/core/index.js
 require('dotenv').config();
-
-// --- 进程级兜底日志（避免“Discord 无响应但控制台无日志”难以排查） ---
-// 可选：设置 FATAL_EXIT_ON_EXCEPTION=true，在发生 uncaughtException 时直接退出（建议配合进程守护工具使用）。
 const FATAL_EXIT_ON_EXCEPTION = String(process.env.FATAL_EXIT_ON_EXCEPTION || '').toLowerCase() === 'true';
-
-process.on('unhandledRejection', (reason) => {
-    console.error('❌ [Process] unhandledRejection:', reason);
-});
-
-process.on('uncaughtException', (err) => {
-    console.error('❌ [Process] uncaughtException:', err);
-    if (FATAL_EXIT_ON_EXCEPTION) {
-        process.exit(1);
-    }
-});
-
-const {
-    Client,
-    Collection,
-    Events, 
-    GatewayIntentBits,
-} = require('discord.js')
-
-const { clientReadyHandler } = require('./events/clientReady')
-const { interactionCreateHandler } = require('./events/interactionCreate')
+process.on('unhandledRejection', (reason) => { console.error('\u274c [Process] unhandledRejection:', reason); });
+process.on('uncaughtException', (err) => { console.error('\u274c [Process] uncaughtException:', err); if (FATAL_EXIT_ON_EXCEPTION) { process.exit(1); } });
+const { Client, Collection, Events, GatewayIntentBits } = require('discord.js');
+const { clientReadyHandler } = require('./events/clientReady');
+const { interactionCreateHandler } = require('./events/interactionCreate');
 const { startProposalChecker } = require('../modules/proposal/services/proposalChecker');
 const { startCourtChecker } = require('../modules/court/services/courtChecker');
 const { startSelfModerationChecker } = require('../modules/selfModeration/services/moderationChecker');
@@ -36,22 +17,9 @@ const { syncMissedActivity } = require('../modules/selfRole/services/autoSyncSer
 const { startSelfRoleApplicationChecker } = require('../modules/selfRole/services/applicationChecker');
 const { startSelfRoleLifecycleScheduler } = require('../modules/selfRole/services/lifecycleScheduler');
 const { startSelfRoleConsistencyChecker } = require('../modules/selfRole/services/consistencyChecker');
-
-// 身份组同步系统（多服务器）
-const {
-    startRoleSyncSystem,
-    roleSyncGuildMemberAddHandler,
-    roleSyncGuildMemberRemoveHandler,
-    roleSyncGuildMemberUpdateHandler,
-    roleSyncGuildRoleDeleteHandler,
-} = require('../modules/roleSync');
-
-// 导入命令
+const { startRoleSyncSystem, roleSyncGuildMemberAddHandler, roleSyncGuildMemberRemoveHandler, roleSyncGuildMemberUpdateHandler, roleSyncGuildRoleDeleteHandler } = require('../modules/roleSync');
 const pingCommand = require('../shared/commands/ping');
-// const debugPermissionsCommand = require('../shared/commands/debugPermissions');  // 需要使用再取消注释
 const setCheckChannelCommand = require('../shared/commands/setCheckChannel');
-
-// 提案系统命令
 const setupFormCommand = require('../modules/proposal/commands/setupForm');
 const deleteEntryCommand = require('../modules/proposal/commands/deleteEntry');
 const withdrawProposalCommand = require('../modules/proposal/commands/withdrawProposal');
@@ -59,24 +27,15 @@ const setFormPermissionsCommand = require('../modules/proposal/commands/setFormP
 const setSupportPermissionsCommand = require('../modules/proposal/commands/setSupportPermissions');
 const reviewProposalCommand = require('../modules/proposal/commands/reviewProposal');
 const setProposalReviewersCommand = require('../modules/proposal/commands/setProposalReviewers');
-
-// 审核系统命令（已合并为 /创作者审核）
 const creatorReviewCommand = require('../modules/creatorReview/commands/creatorReview');
-
-// 法庭系统命令
 const setAllowCourtRoleCommand = require('../modules/court/commands/setAllowCourtRole');
 const applyToCourtCommand = require('../modules/court/commands/applyToCourt');
-
-// 自助管理系统命令
 const deleteShitMessageCommand = require('../modules/selfModeration/commands/deleteShitMessage');
 const muteShitUserCommand = require('../modules/selfModeration/commands/muteShitUser');
 const seriousMuteCommand = require('../modules/selfModeration/commands/seriousMute');
-// 8 个配置指令已合并为 /搬石公投配置
 const selfModerationConfigCommand = require('../modules/selfModeration/commands/selfModerationConfig');
 const checkMyCooldownCommand = require('../modules/selfModeration/commands/checkMyCooldown');
 const getArchiveViewPermissionCommand = require('../modules/selfModeration/commands/getArchiveViewPermission');
-
-// 赛事系统命令
 const setupContestApplicationCommand = require('../modules/contest/commands/setupContestApplication');
 const manageTrackCommand = require('../modules/contest/commands/manageTrack');
 const setContestReviewersCommand = require('../modules/contest/commands/setContestReviewers');
@@ -98,35 +57,23 @@ const syncTournamentCommand = require('../modules/contest/commands/syncTournamen
 const deleteTournamentCommand = require('../modules/contest/commands/deleteTournament');
 const listBooklistsCommand = require('../modules/contest/commands/listBooklists');
 const manageSyncExclusionCommand = require('../modules/contest/commands/manageSyncExclusion');
-
-// 自动清理系统命令（合并后）
 const keywordManagerCommand = require('../modules/autoCleanup/commands/keywordManager');
 const exemptManagerCommand = require('../modules/autoCleanup/commands/exemptManager');
 const cleanupManagerCommand = require('../modules/autoCleanup/commands/cleanupManager');
-
-// 频道总结系统命令
 const summarizeChannelCommand = require('../modules/channelSummary/commands/summarizeChannel');
 const summaryPresetCommand = require('../modules/channelSummary/commands/summaryPreset');
-
-// 投票系统命令
 const createVoteCommand = require('../modules/voting/commands/createVote');
-// 添加新的通知身份组命令
 const notificationRolesCommand = require('../modules/voting/commands/notificationRoles');
-
 const { messageCreateHandler } = require('./events/messageCreate');
-
-// 自助文件上传系统命令
 const uploadCommand = require('../modules/selfFileUpload/commands/uploadFile');
 const whoisCommand = require('../modules/selfFileUpload/commands/queryAnonymousLog');
 const manageOptOutCommand = require('../modules/selfFileUpload/commands/manageOptOut.js');
 const collectBackupsCommand = require('../modules/selfFileUpload/commands/collectBackups.js');
-
-//// 自助身份组系统命令
 const setupRolePanelCommand = require('../modules/selfRole/commands/setupRolePanel');
 const setupAdminPanelCommand = require('../modules/selfRole/commands/setupAdminPanel');
 const recalculateActivityCommand = require('../modules/selfRole/commands/recalculateActivity');
 const checkActivityCommand = require('../modules/selfRole/commands/checkActivity');
-const debugRolesCommand = require('../modules/selfRole/commands/debugRoles'); // 调试命令
+const debugRolesCommand = require('../modules/selfRole/commands/debugRoles');
 const clearCooldownCommand = require('../modules/selfRole/commands/clearCooldown');
 const configureRolesCommand = require('../modules/selfRole/commands/configureRoles');
 const withdrawSelfRoleApplicationCommand = require('../modules/selfRole/commands/withdrawApplication');
@@ -134,111 +81,44 @@ const selfRoleOpsCommand = require('../modules/selfRole/commands/selfRoleOps');
 const selfRoleWizardCommand = require('../modules/selfRole/commands/selfRoleWizard');
 let selfRoleTestCommand = null;
 if (String(process.env.SELF_ROLE_ENABLE_TEST_COMMANDS || '').toLowerCase() === 'true') {
-    // 仅在测试环境启用（避免生产环境误注册）
     selfRoleTestCommand = require('../modules/selfRole/commands/selfRoleTest');
-    console.log('[SelfRole] 🧪 SELF_ROLE_ENABLE_TEST_COMMANDS=true：已启用自助身份组测试命令注册。');
+    console.log('[SelfRole] test commands enabled.');
 }
-
-// 身份组同步系统命令
 const roleSyncConfigCommand = require('../modules/roleSync/commands/roleSyncConfig');
-
-// 处罚系统
 const { startPunishmentSystem } = require('../modules/punishment');
 const punishCommand = require('../modules/punishment/commands/punish');
 const disciplineCommand = require('../modules/punishment/commands/discipline');
 const disciplineConfigCommand = require('../modules/punishment/commands/disciplineConfig');
-
-// 机器人消息管理系统（编辑 bot 已发出的常驻消息）
 const { startBotMessageSystem } = require('../modules/botMessage');
 const botMessageCommand = require('../modules/botMessage/commands/botMessage');
 const editBotMessageContextCommand = require('../modules/botMessage/commands/editBotMessageContext');
-
-// 分服受控邀请系统
 const { startControlledInviteSystem, controlledInviteGuildMemberAddHandler } = require('../modules/controlledInvite');
 const controlledInviteConfigCommand = require('../modules/controlledInvite/commands/controlledInviteConfig');
 const controlledInviteParamsCommand = require('../modules/controlledInvite/commands/controlledInviteParams');
 const controlledInviteToggleCommand = require('../modules/controlledInvite/commands/controlledInviteToggle');
 const viewMyControlledInviteStatusCommand = require('../modules/controlledInvite/commands/viewMyControlledInviteStatus');
-
-// Discord 安全措施（邀请暂停托管）
 const { startSafetySetupSystem } = require('../modules/safetySetup');
-
-// 神秘指令娱乐系统
 const mysteryCommand = require('../modules/mystery/commands/mysteryCommand');
 const manageCommand = require('../modules/mystery/commands/manageCommand');
 const mysteryGameStatsCommand = require('../modules/mystery/commands/gameStatsCommand');
+const mysteryToggleCommand = require('../modules/mystery/commands/mysteryToggleCommand');
 const { mysteryGuildMemberRemoveHandler } = require('../modules/mystery/events/guildMemberRemove');
 const { mysteryGuildMemberUpdateHandler } = require('../modules/mystery/events/guildMemberUpdate');
-const {
-    handleGuildMemberUpdate: cowardPenaltyGuildMemberUpdateHandler,
-    startCowardPenaltyRestorer,
-} = require('../modules/mystery/services/cowardPenalty');
-
-const DISCORD_REST_TIMEOUT_MS = (() => {
-    const n = Number(process.env.DISCORD_REST_TIMEOUT_MS);
-    return Number.isFinite(n) && n > 0 ? n : 15000;
-})();
-
-const client = new Client({
-    intents: [
-        GatewayIntentBits.Guilds,
-        GatewayIntentBits.GuildMessages,
-        GatewayIntentBits.GuildMembers,
-        GatewayIntentBits.GuildMessageReactions, // 需要这个intent来监控reaction
-        GatewayIntentBits.MessageContent,
-    ],
-    rest: {
-        // REST 请求超时（ms）。避免网络异常时请求长时间挂起导致交互无响应。
-        timeout: DISCORD_REST_TIMEOUT_MS,
-    },
-});
-
-// --- Discord 客户端/REST 诊断日志（用于定位“无响应但无日志”） ---
-client.on('error', (err) => {
-    console.error('❌ [Discord] client error:', err);
-});
-client.on('warn', (info) => {
-    console.warn('⚠️ [Discord] client warn:', info);
-});
-client.on('shardError', (err, shardId) => {
-    console.error(`❌ [Discord] shardError shard=${shardId}:`, err);
-});
-client.on('shardDisconnect', (event, shardId) => {
-    console.warn(`⚠️ [Discord] shardDisconnect shard=${shardId} code=${event?.code} reason=${event?.reason}`);
-});
-client.on('shardReconnecting', (shardId) => {
-    console.warn(`⚠️ [Discord] shardReconnecting shard=${shardId}`);
-});
-client.on('shardResume', (shardId, replayedEvents) => {
-    console.log(`✅ [Discord] shardResume shard=${shardId} replayed=${replayedEvents}`);
-});
-
-try {
-    client.rest.on('rateLimited', (info) => {
-        const route = info?.route || info?.path || 'unknown';
-        const method = info?.method || 'unknown';
-        const timeToReset = info?.timeToReset;
-        console.warn(`⚠️ [Discord][REST] rateLimited ${method} ${route} resetInMs=${timeToReset}`);
-    });
-} catch (_) {}
-
+const { handleGuildMemberUpdate: cowardPenaltyGuildMemberUpdateHandler, startCowardPenaltyRestorer } = require('../modules/mystery/services/cowardPenalty');
+const DISCORD_REST_TIMEOUT_MS = (() => { const n = Number(process.env.DISCORD_REST_TIMEOUT_MS); return Number.isFinite(n) && n > 0 ? n : 15000; })();
+const client = new Client({ intents: [GatewayIntentBits.Guilds, GatewayIntentBits.GuildMessages, GatewayIntentBits.GuildMembers, GatewayIntentBits.GuildMessageReactions, GatewayIntentBits.MessageContent], rest: { timeout: DISCORD_REST_TIMEOUT_MS } });
+client.on('error', (err) => { console.error('\u274c [Discord] client error:', err); });
+client.on('warn', (info) => { console.warn('\u26a0\ufe0f [Discord] client warn:', info); });
+client.on('shardError', (err, shardId) => { console.error(`\u274c [Discord] shardError shard=${shardId}:`, err); });
+client.on('shardDisconnect', (event, shardId) => { console.warn(`\u26a0\ufe0f [Discord] shardDisconnect shard=${shardId} code=${event?.code} reason=${event?.reason}`); });
+client.on('shardReconnecting', (shardId) => { console.warn(`\u26a0\ufe0f [Discord] shardReconnecting shard=${shardId}`); });
+client.on('shardResume', (shardId, replayedEvents) => { console.log(`\u2705 [Discord] shardResume shard=${shardId} replayed=${replayedEvents}`); });
+try { client.rest.on('rateLimited', (info) => { const route = info?.route || info?.path || 'unknown'; const method = info?.method || 'unknown'; const timeToReset = info?.timeToReset; console.warn(`\u26a0\ufe0f [Discord][REST] rateLimited ${method} ${route} resetInMs=${timeToReset}`); }); } catch (_) {}
 const HEALTH_LOG_INTERVAL_MINUTES = Number(process.env.HEALTH_LOG_INTERVAL_MINUTES || 0);
-if (Number.isFinite(HEALTH_LOG_INTERVAL_MINUTES) && HEALTH_LOG_INTERVAL_MINUTES > 0) {
-    setInterval(() => {
-        console.log(
-            `[Health] wsStatus=${client.ws?.status} ping=${client.ws?.ping} guilds=${client.guilds?.cache?.size} mem=${Math.round(process.memoryUsage().rss / 1024 / 1024)}MB`,
-        );
-    }, Math.floor(HEALTH_LOG_INTERVAL_MINUTES * 60 * 1000));
-}
-
+if (Number.isFinite(HEALTH_LOG_INTERVAL_MINUTES) && HEALTH_LOG_INTERVAL_MINUTES > 0) { setInterval(() => { console.log(`[Health] wsStatus=${client.ws?.status} ping=${client.ws?.ping} guilds=${client.guilds?.cache?.size} mem=${Math.round(process.memoryUsage().rss / 1024 / 1024)}MB`); }, Math.floor(HEALTH_LOG_INTERVAL_MINUTES * 60 * 1000)); }
 client.commands = new Collection();
-
-// 注册所有命令
 client.commands.set(pingCommand.data.name, pingCommand);
-// client.commands.set(debugPermissionsCommand.data.name, debugPermissionsCommand); // 需要使用再取消注释
 client.commands.set(setCheckChannelCommand.data.name, setCheckChannelCommand);
-
-// 提案系统命令
 client.commands.set(setupFormCommand.data.name, setupFormCommand);
 client.commands.set(deleteEntryCommand.data.name, deleteEntryCommand);
 client.commands.set(withdrawProposalCommand.data.name, withdrawProposalCommand);
@@ -246,23 +126,15 @@ client.commands.set(setFormPermissionsCommand.data.name, setFormPermissionsComma
 client.commands.set(setSupportPermissionsCommand.data.name, setSupportPermissionsCommand);
 client.commands.set(reviewProposalCommand.data.name, reviewProposalCommand);
 client.commands.set(setProposalReviewersCommand.data.name, setProposalReviewersCommand);
-
-// 审核系统命令（已合并为 /创作者审核）
 client.commands.set(creatorReviewCommand.data.name, creatorReviewCommand);
-
-// 法庭系统命令
 client.commands.set(setAllowCourtRoleCommand.data.name, setAllowCourtRoleCommand);
 client.commands.set(applyToCourtCommand.data.name, applyToCourtCommand);
-
-// 自助管理系统命令
 client.commands.set(deleteShitMessageCommand.data.name, deleteShitMessageCommand);
 client.commands.set(muteShitUserCommand.data.name, muteShitUserCommand);
 client.commands.set(seriousMuteCommand.data.name, seriousMuteCommand);
 client.commands.set(selfModerationConfigCommand.data.name, selfModerationConfigCommand);
 client.commands.set(checkMyCooldownCommand.data.name, checkMyCooldownCommand);
 client.commands.set(getArchiveViewPermissionCommand.data.name, getArchiveViewPermissionCommand);
-
-// 赛事系统命令
 client.commands.set(setupContestApplicationCommand.data.name, setupContestApplicationCommand);
 client.commands.set(manageTrackCommand.data.name, manageTrackCommand);
 client.commands.set(setContestReviewersCommand.data.name, setContestReviewersCommand);
@@ -284,148 +156,66 @@ client.commands.set(syncTournamentCommand.data.name, syncTournamentCommand);
 client.commands.set(deleteTournamentCommand.data.name, deleteTournamentCommand);
 client.commands.set(listBooklistsCommand.data.name, listBooklistsCommand);
 client.commands.set(manageSyncExclusionCommand.data.name, manageSyncExclusionCommand);
-
-// 自动清理系统命令（合并后）
 client.commands.set(keywordManagerCommand.data.name, keywordManagerCommand);
 client.commands.set(exemptManagerCommand.data.name, exemptManagerCommand);
 client.commands.set(cleanupManagerCommand.data.name, cleanupManagerCommand);
-
-// 频道总结系统命令
 client.commands.set(summarizeChannelCommand.data.name, summarizeChannelCommand);
 client.commands.set(summaryPresetCommand.data.name, summaryPresetCommand);
-
-// 投票系统命令
 client.commands.set(createVoteCommand.data.name, createVoteCommand);
-// 注册新的通知身份组命令
 client.commands.set(notificationRolesCommand.data.name, notificationRolesCommand);
-
-// 自助文件上传系统命令
 client.commands.set(uploadCommand.data.name, uploadCommand);
 client.commands.set(whoisCommand.data.name, whoisCommand);
 client.commands.set(manageOptOutCommand.data.name, manageOptOutCommand);
 client.commands.set(collectBackupsCommand.data.name, collectBackupsCommand);
-
-//// 自助身份组系统命令
 client.commands.set(setupRolePanelCommand.data.name, setupRolePanelCommand);
 client.commands.set(setupAdminPanelCommand.data.name, setupAdminPanelCommand);
 client.commands.set(recalculateActivityCommand.data.name, recalculateActivityCommand);
 client.commands.set(checkActivityCommand.data.name, checkActivityCommand);
-client.commands.set(debugRolesCommand.data.name, debugRolesCommand); // 调试命令
+client.commands.set(debugRolesCommand.data.name, debugRolesCommand);
 client.commands.set(clearCooldownCommand.data.name, clearCooldownCommand);
 client.commands.set(configureRolesCommand.data.name, configureRolesCommand);
 client.commands.set(withdrawSelfRoleApplicationCommand.data.name, withdrawSelfRoleApplicationCommand);
 client.commands.set(selfRoleOpsCommand.data.name, selfRoleOpsCommand);
 client.commands.set(selfRoleWizardCommand.data.name, selfRoleWizardCommand);
-if (selfRoleTestCommand) {
-    client.commands.set(selfRoleTestCommand.data.name, selfRoleTestCommand);
-}
+if (selfRoleTestCommand) { client.commands.set(selfRoleTestCommand.data.name, selfRoleTestCommand); }
 client.commands.set(roleSyncConfigCommand.data.name, roleSyncConfigCommand);
-
-// 处罚系统命令
 client.commands.set(punishCommand.data.name, punishCommand);
 client.commands.set(disciplineCommand.data.name, disciplineCommand);
 client.commands.set(disciplineConfigCommand.data.name, disciplineConfigCommand);
-
-// 机器人消息管理系统命令
 client.commands.set(botMessageCommand.data.name, botMessageCommand);
 client.commands.set(editBotMessageContextCommand.data.name, editBotMessageContextCommand);
-
-// 分服受控邀请系统命令
 client.commands.set(controlledInviteConfigCommand.data.name, controlledInviteConfigCommand);
 client.commands.set(controlledInviteParamsCommand.data.name, controlledInviteParamsCommand);
 client.commands.set(controlledInviteToggleCommand.data.name, controlledInviteToggleCommand);
 client.commands.set(viewMyControlledInviteStatusCommand.data.name, viewMyControlledInviteStatusCommand);
-
-// Discord 安全措施与神秘管理工具（统一为唯一 /管理）
 client.commands.set(manageCommand.data.name, manageCommand);
-
-// 神秘指令娱乐系统
 client.commands.set(mysteryCommand.data.name, mysteryCommand);
 client.commands.set(mysteryGameStatsCommand.data.name, mysteryGameStatsCommand);
-
-// 加压轮盘测试指令：仅在 .env 里设置 MYSTERY_TEST_COMMANDS=true 时才注册，
-// 避免测试用的虚拟机器人局出现在正式服务器的指令列表里。
-if (String(process.env.MYSTERY_TEST_COMMANDS).toLowerCase() === 'true') {
-    const pressureTestCommand = require('../modules/mystery/commands/pressureTestCommand');
-    client.commands.set(pressureTestCommand.data.name, pressureTestCommand);
-    console.log('🧪 加压轮盘测试指令已注册（MYSTERY_TEST_COMMANDS=true）');
-}
-
+client.commands.set(mysteryToggleCommand.data.name, mysteryToggleCommand);
+if (String(process.env.MYSTERY_TEST_COMMANDS).toLowerCase() === 'true') { const pressureTestCommand = require('../modules/mystery/commands/pressureTestCommand'); client.commands.set(pressureTestCommand.data.name, pressureTestCommand); console.log('test mystery commands registered'); }
 client.once(Events.ClientReady, async (readyClient) => {
-    try {
-        // 启动时强制同步命令（clientReadyHandler 内部会执行 rest.put 刷新命令）
-        // 若开启 STRICT_COMMAND_SYNC=true 且存在失败 guild，将直接抛错并中止启动。
-        await clientReadyHandler(readyClient);
-    } catch (err) {
-        console.error('❌ 启动阶段命令同步失败，进程即将退出：', err);
-        try {
-            readyClient.destroy();
-        } catch (_) {}
-        process.exit(1);
-        return;
-    }
+    try { await clientReadyHandler(readyClient); } catch (err) { console.error('\u274c startup command sync failed:', err); try { readyClient.destroy(); } catch (_) {} process.exit(1); return; }
     printTimeConfig();
-    
-    startProposalChecker(readyClient);
-    console.log('✅ 提案检查器已启动');
-    
-    startCourtChecker(readyClient);
-    console.log('✅ 法庭系统检查器已启动');
-    
-    startSelfModerationChecker(readyClient);
-    console.log('✅ 自助管理检查器已启动');
-    
-    startAttachmentCleanupScheduler(readyClient);
-    console.log('✅ 附件清理定时器已启动');
-    
-    startVoteChecker(readyClient);
-    console.log('✅ 投票检查器已启动');
-    
-    // 初始化自动清理系统
-    console.log('✅ 自动清理系统已启动');
-
+    startProposalChecker(readyClient); console.log('\u2705 proposal checker started');
+    startCourtChecker(readyClient); console.log('\u2705 court checker started');
+    startSelfModerationChecker(readyClient); console.log('\u2705 self-moderation checker started');
+    startAttachmentCleanupScheduler(readyClient); console.log('\u2705 attachment cleanup scheduler started');
+    startVoteChecker(readyClient); console.log('\u2705 vote checker started');
+    console.log('\u2705 auto cleanup system started');
     startActivityTracker();
-
-    // 恢复未结束的「胆小鬼」昵称惩罚，避免重启后 🤡 前缀永久卡在别人名字上
-    await startCowardPenaltyRestorer(readyClient);
-    console.log('✅ 胆小鬼惩罚恢复完成');
-
-    // SelfRole 申请过期检查器（预留名额释放/旧数据兼容迁移）
+    await startCowardPenaltyRestorer(readyClient); console.log('\u2705 coward penalty restorer done');
     startSelfRoleApplicationChecker(readyClient);
-    
-    // 在机器人完全启动前，执行离线数据同步
     await syncMissedActivity(readyClient);
-
-    // SelfRole grant 生命周期调度器（周期询问/onlyWhenFull/强制清退）
     startSelfRoleLifecycleScheduler(readyClient);
-
-    // SelfRole 一致性巡检（grant/面板/角色残留等）
     startSelfRoleConsistencyChecker(readyClient);
-
-    // 启动身份组同步系统
     await startRoleSyncSystem(readyClient);
-
-    // 启动处罚系统
     await startPunishmentSystem(readyClient);
-
-    // 启动机器人消息管理系统
     await startBotMessageSystem(readyClient);
-
-    // 启动分服受控邀请系统
     await startControlledInviteSystem(readyClient);
-
-    // 启动 Discord 安全措施邀请暂停托管
     await startSafetySetupSystem(readyClient);
-
-    console.log('\n🤖 机器人已完全启动，所有系统正常运行！');
-    console.log('🏆 赛事管理系统已加载');
-    console.log('🧹 自动消息清理系统已加载');
-    console.log('📝 机器人消息管理系统已加载');
-})
-
-client.on(Events.InteractionCreate, interactionCreateHandler)
-
-// 添加消息创建事件处理器
+    console.log('\n\ud83e\udd16 Bot fully started, all systems operational!');
+});
+client.on(Events.InteractionCreate, interactionCreateHandler);
 client.on(Events.MessageCreate, messageCreateHandler);
 client.on(Events.GuildMemberAdd, roleSyncGuildMemberAddHandler);
 client.on(Events.GuildMemberAdd, controlledInviteGuildMemberAddHandler);
@@ -435,31 +225,9 @@ client.on(Events.GuildRoleDelete, roleSyncGuildRoleDeleteHandler);
 client.on(Events.GuildMemberRemove, mysteryGuildMemberRemoveHandler);
 client.on(Events.GuildMemberUpdate, mysteryGuildMemberUpdateHandler);
 client.on(Events.GuildMemberUpdate, cowardPenaltyGuildMemberUpdateHandler);
-
-function normalizeDiscordToken(raw) {
-    if (!raw) return '';
-    let token = String(raw).trim();
-    if (!token) return '';
-    // 兼容误填 "Bot <token>"
-    token = token.replace(/^Bot\s+/i, '').trim();
-    return token;
-}
-
+function normalizeDiscordToken(raw) { if (!raw) return ''; let token = String(raw).trim(); if (!token) return ''; token = token.replace(/^Bot\s+/i, '').trim(); return token; }
 const token = normalizeDiscordToken(process.env.DISCORD_TOKEN);
-if (!token || token.includes('PASTE_YOUR_DISCORD_BOT_TOKEN')) {
-    console.error('❌ 缺少或未正确配置 DISCORD_TOKEN。请在项目根目录 .env 中设置 DISCORD_TOKEN=你的机器人Token 后重启。');
-    process.exit(1);
-}
-if (token.split('.').length !== 3) {
-    console.error('❌ DISCORD_TOKEN 格式异常：应为 3 段以英文点号分隔的 token。请检查是否有空格/换行/前缀 Bot 等。');
-    process.exit(1);
-}
-
-// 确保后续模块（如命令同步）拿到的是清洗后的 token
+if (!token || token.includes('PASTE_YOUR_DISCORD_BOT_TOKEN')) { console.error('\u274c Missing DISCORD_TOKEN'); process.exit(1); }
+if (token.split('.').length !== 3) { console.error('\u274c DISCORD_TOKEN format error'); process.exit(1); }
 process.env.DISCORD_TOKEN = token;
-
-client.login(token).catch((err) => {
-    console.error('❌ Discord 登录失败。常见原因：Token 粘贴错误 / Token 已被重置失效 / 使用了非 Bot Token。');
-    console.error(err);
-    process.exit(1);
-});
+client.login(token).catch((err) => { console.error('\u274c Discord login failed:', err); process.exit(1); });

--- a/src/modules/mystery/commands/mysteryCommand.js
+++ b/src/modules/mystery/commands/mysteryCommand.js
@@ -16,6 +16,7 @@ const { startBomb } = require('../services/bombGame');
 const { startDuel } = require('../services/duelGame');
 const { startPressureRoulette } = require('../services/pressureRouletteGame');
 const { getNames } = require('../services/namePoolStore');
+const { isChannelBlocked } = require('../utils/mysteryChannelBlocklist');
 
 const SUBCOMMAND_SELF_TIMEOUT = '自刎归天';
 const SUBCOMMAND_RANDOM_NICKNAME = '取名字好麻烦';
@@ -45,6 +46,7 @@ const TIMEOUT_FAILURE_MESSAGE = '❌ 神秘力量失效了，我无法对你施�
 const NICKNAME_FAILURE_MESSAGE = '❌ 名字取好了，但我改不了你的昵称。\n可能是机器人权限或身份组层级不足。';
 const GENERIC_FAILURE_MESSAGE = '❌ 处理神秘指令时出现错误，请稍后重试。';
 const PLAYER_BUSY_MESSAGE = '🚫 **一心不能二用。**\n你现在已经在一场神秘游戏里，先把那边活着玩完再说。';
+const CHANNEL_BLOCKED_MESSAGE = '🚫 **神秘指令在本频道/子区已被禁用。**\n请到其他频道使用。';
 const initiationQueues = new Map();
 
 const data = new SlashCommandBuilder()
@@ -226,12 +228,20 @@ async function execute(interaction) {
             await interaction.reply({ content: '❌ 此指令只能在服务器中使用。', flags: MessageFlags.Ephemeral });
             return;
         }
+
+        // 检查当前频道/子区是否被禁用了神秘指令
+        guildId = interaction.guild.id;
+        const channelId = interaction.channel?.id || interaction.channelId;
+        if (isChannelBlocked(guildId, channelId)) {
+            await interaction.reply({ content: CHANNEL_BLOCKED_MESSAGE, flags: MessageFlags.Ephemeral });
+            return;
+        }
+
         subcommand = interaction.options.getSubcommand(false);
         if (!VALID_SUBCOMMANDS.includes(subcommand)) {
             await interaction.reply({ content: '❌ 未知的神秘指令。', flags: MessageFlags.Ephemeral });
             return;
         }
-        guildId = interaction.guild.id;
         userId = interaction.user.id;
         lockAcquired = acquireInFlight(guildId, userId, subcommand);
         if (!lockAcquired) {

--- a/src/modules/mystery/commands/mysteryToggleCommand.js
+++ b/src/modules/mystery/commands/mysteryToggleCommand.js
@@ -1,0 +1,103 @@
+const { MessageFlags, SlashCommandBuilder, ChannelType } = require('discord.js');
+const {
+    checkAdminPermission,
+} = require('../../../core/utils/permissionManager');
+const {
+    isChannelBlocked,
+    blockChannel,
+    unblockChannel,
+} = require('../utils/mysteryChannelBlocklist');
+
+const THREAD_TYPES = new Set([
+    ChannelType.PublicThread,
+    ChannelType.PrivateThread,
+    ChannelType.AnnouncementThread,
+]);
+
+const data = new SlashCommandBuilder()
+    .setName('神秘指令开关')
+    .setDescription('在当前子区/频道内禁用或启用神秘指令')
+    .addSubcommand(subcommand => subcommand
+        .setName('禁用')
+        .setDescription('在当前子区/频道内禁用所有神秘指令'))
+    .addSubcommand(subcommand => subcommand
+        .setName('启用')
+        .setDescription('在当前子区/频道内重新启用神秘指令'));
+
+/**
+ * 判断用户是否有权操作当前频道的神秘指令开关。
+ * - 管理员：任何频道都可以
+ * - 子区主 (thread owner)：只能在自己创建的子区内
+ */
+function hasTogglePermission(interaction) {
+    // 管理员始终有权
+    if (checkAdminPermission(interaction.member)) return true;
+
+    const channel = interaction.channel;
+    // 非子区类型的频道，只有管理员能操作
+    if (!channel || !THREAD_TYPES.has(channel.type)) return false;
+
+    // 子区主可以操作自己的子区
+    return channel.ownerId === interaction.user.id;
+}
+
+async function execute(interaction) {
+    if (!interaction.inGuild()) {
+        await interaction.reply({
+            content: '❌ 此命令只能在服务器中使用。',
+            flags: MessageFlags.Ephemeral,
+        });
+        return;
+    }
+
+    if (!hasTogglePermission(interaction)) {
+        const channel = interaction.channel;
+        const isThread = channel && THREAD_TYPES.has(channel.type);
+        const hint = isThread
+            ? '只有本子区的创建者或管理员才能操作此开关。'
+            : '只有管理员才能在普通频道操作此开关。';
+        await interaction.reply({
+            content: `❌ 你没有权限操作。${hint}`,
+            flags: MessageFlags.Ephemeral,
+        });
+        return;
+    }
+
+    const subcommand = interaction.options.getSubcommand(false);
+    const guildId = interaction.guild.id;
+    const channelId = interaction.channel.id;
+    const channelName = interaction.channel.name || '当前频道';
+
+    if (subcommand === '禁用') {
+        const added = blockChannel(guildId, channelId, interaction.user.id);
+        if (added) {
+            await interaction.reply({
+                content: `🚫 已在「${channelName}」中禁用所有神秘指令。\n使用 \`/神秘指令开关 启用\` 可重新启用。`,
+            });
+        } else {
+            await interaction.reply({
+                content: `ℹ️ 「${channelName}」的神秘指令已经是禁用状态。`,
+                flags: MessageFlags.Ephemeral,
+            });
+        }
+    } else if (subcommand === '启用') {
+        const removed = unblockChannel(guildId, channelId);
+        if (removed) {
+            await interaction.reply({
+                content: `✅ 已在「${channelName}」中重新启用神秘指令。`,
+            });
+        } else {
+            await interaction.reply({
+                content: `ℹ️ 「${channelName}」的神秘指令本来就是启用状态。`,
+                flags: MessageFlags.Ephemeral,
+            });
+        }
+    } else {
+        await interaction.reply({
+            content: '❌ 未知的操作。',
+            flags: MessageFlags.Ephemeral,
+        });
+    }
+}
+
+module.exports = { data, execute };

--- a/src/modules/mystery/commands/pressureTestCommand.js
+++ b/src/modules/mystery/commands/pressureTestCommand.js
@@ -3,131 +3,44 @@ const {
     checkAdminPermission,
     getPermissionDeniedMessage,
 } = require('../../../core/utils/permissionManager');
-const gameManager = require('../services/mysteryGameManager');
 const { startPressureRoulette } = require('../services/pressureRouletteGame');
+const gameManager = require('../services/mysteryGameManager');
+const { isChannelBlocked } = require('../utils/mysteryChannelBlocklist');
 
-const DEFAULT_BOT_COUNT = 3;
-const MIN_BOT_COUNT = 1;
-const MAX_BOT_COUNT = 5;
-const MIN_TURN_SECONDS = 5;
-const MAX_TURN_SECONDS = 300;
-const CHAMBER_COUNT = 6;
+const data = new SlashCommandBuilder()
+    .setName('加压轮盘测试')
+    .setDescription('⚙️ 用虚拟机器人开一局加压轮盘（仅管理员）')
+    .addIntegerOption(option => option
+        .setName('机器人人数')
+        .setDescription('虚拟机器人玩家数（1–5）')
+        .setRequired(false)
+        .setMinValue(1)
+        .setMaxValue(5));
 
-const NOT_IN_GUILD_MESSAGE = '❌ 此命令只能在服务器中使用。';
-const UNEXPECTED_ERROR_MESSAGE = '❌ 开启测试局时出现错误，请查看日志。';
-
-function buildData() {
-    return new SlashCommandBuilder()
-        .setName('加压轮盘测试')
-        .setDescription('【测试用】用虚拟机器人凑人数，单人也能跑通整局加压俄罗斯轮盘')
-        .addIntegerOption(option => option
-            .setName('机器人数量')
-            .setDescription(`补几个自动行动的测试机器人（${MIN_BOT_COUNT}-${MAX_BOT_COUNT}，默认 ${DEFAULT_BOT_COUNT}）`)
-            .setMinValue(MIN_BOT_COUNT)
-            .setMaxValue(MAX_BOT_COUNT)
-            .setRequired(false))
-        .addIntegerOption(option => option
-            .setName('回合时限')
-            .setDescription(`每回合多少秒（${MIN_TURN_SECONDS}-${MAX_TURN_SECONDS}，默认 60）`)
-            .setMinValue(MIN_TURN_SECONDS)
-            .setMaxValue(MAX_TURN_SECONDS)
-            .setRequired(false))
-        .addIntegerOption(option => option
-            .setName('子弹巢位')
-            .setDescription(`把第一发子弹钉在第几个弹巢（1-${CHAMBER_COUNT}，不填则随机）`)
-            .setMinValue(1)
-            .setMaxValue(CHAMBER_COUNT)
-            .setRequired(false))
-        .addBooleanOption(option => option
-            .setName('等待招募')
-            .setDescription('true = 照常等 3 分钟招募真人；默认 false，立即开打')
-            .setRequired(false))
-        .addBooleanOption(option => option
-            .setName('保留消息')
-            .setDescription('true = 不删除旧面板，保留整局所有消息（调试用）；默认 false，按 3 条滚动窗口清理')
-            .setRequired(false));
-}
-
-function createPressureTestCommand({
-    startGame = startPressureRoulette,
-    checkPermission = checkAdminPermission,
-    permissionDeniedMessage = getPermissionDeniedMessage,
-    manager = gameManager,
-} = {}) {
-    const data = buildData();
-
-    async function execute(interaction) {
-        try {
-            if (!interaction.inGuild()) {
-                await interaction.reply({
-                    content: NOT_IN_GUILD_MESSAGE,
-                    flags: MessageFlags.Ephemeral,
-                });
-                return;
-            }
-            if (!checkPermission(interaction.member)) {
-                await interaction.reply({
-                    content: permissionDeniedMessage(),
-                    flags: MessageFlags.Ephemeral,
-                });
-                return;
-            }
-
-            // 测试指令不走 30 分钟冷却，但仍然尊重玩家锁和频道锁，
-            // 避免把正在进行的那局踩掉。频道锁是四个游戏共用的，
-            // 所以频道里有任意一场神秘游戏时测试局都开不了。
-            const guildId = interaction.guild.id;
-            const userId = interaction.user.id;
-            const channelBusy = manager.getChannelGame(interaction.channelId);
-            if (manager.getPlayerGame(guildId, userId) || channelBusy) {
-                await interaction.reply({
-                    content: '🎮 **这个频道已经有一场神秘游戏在进行了，或者你本人正在别的游戏里。**\n等它结束，或换个频道再开测试局。',
-                    flags: MessageFlags.Ephemeral,
-                });
-                return;
-            }
-
-            const botCount = interaction.options.getInteger('机器人数量') ?? DEFAULT_BOT_COUNT;
-            const turnSeconds = interaction.options.getInteger('回合时限');
-            const bulletChamber = interaction.options.getInteger('子弹巢位') ?? 0;
-            const waitForRecruitment = interaction.options.getBoolean('等待招募') === true;
-            const keepMessages = interaction.options.getBoolean('保留消息') === true;
-
-            await startGame(interaction, {
-                test: {
-                    botCount,
-                    bulletChamber,
-                    immediate: !waitForRecruitment,
-                    keepMessages,
-                },
-                turnDurationMs: turnSeconds ? turnSeconds * 1000 : undefined,
-            });
-        } catch (error) {
-            console.error(
-                `[MysteryPressureTest] 开启测试局失败 (guild=${interaction.guild?.id || 'dm'}, user=${interaction.user?.id}):`,
-                error
-            );
-            try {
-                if (interaction.deferred && !interaction.replied) {
-                    await interaction.editReply({ content: UNEXPECTED_ERROR_MESSAGE });
-                } else if (!interaction.replied) {
-                    await interaction.reply({
-                        content: UNEXPECTED_ERROR_MESSAGE,
-                        flags: MessageFlags.Ephemeral,
-                    });
-                }
-            } catch (replyError) {
-                console.error('[MysteryPressureTest] 回复异常提示失败:', replyError);
-            }
-        }
+async function execute(interaction) {
+    if (!interaction.inGuild()) {
+        await interaction.reply({ content: '❌ 此命令只能在服务器中使用。', flags: MessageFlags.Ephemeral });
+        return;
+    }
+    if (!checkAdminPermission(interaction.member)) {
+        await interaction.reply({ content: getPermissionDeniedMessage(), flags: MessageFlags.Ephemeral });
+        return;
     }
 
-    return { data, execute };
+    // 检查频道禁用
+    if (isChannelBlocked(interaction.guild.id, interaction.channel?.id || interaction.channelId)) {
+        await interaction.reply({ content: '🚫 **神秘指令在本频道/子区已被禁用。**', flags: MessageFlags.Ephemeral });
+        return;
+    }
+
+    const existing = gameManager.getChannelGame(interaction.channel.id);
+    if (existing) {
+        await interaction.reply({ content: '❌ 本频道已有游戏正在进行。', flags: MessageFlags.Ephemeral });
+        return;
+    }
+
+    const botCount = interaction.options.getInteger('机器人人数') ?? 2;
+    await startPressureRoulette(interaction, { testBotCount: botCount });
 }
 
-const command = createPressureTestCommand();
-
-module.exports = {
-    ...command,
-    createPressureTestCommand,
-};
+module.exports = { data, execute };

--- a/src/modules/mystery/commands/pressureTestCommand.js
+++ b/src/modules/mystery/commands/pressureTestCommand.js
@@ -3,44 +3,142 @@ const {
     checkAdminPermission,
     getPermissionDeniedMessage,
 } = require('../../../core/utils/permissionManager');
-const { startPressureRoulette } = require('../services/pressureRouletteGame');
 const gameManager = require('../services/mysteryGameManager');
+const { startPressureRoulette } = require('../services/pressureRouletteGame');
 const { isChannelBlocked } = require('../utils/mysteryChannelBlocklist');
 
-const data = new SlashCommandBuilder()
-    .setName('加压轮盘测试')
-    .setDescription('⚙️ 用虚拟机器人开一局加压轮盘（仅管理员）')
-    .addIntegerOption(option => option
-        .setName('机器人人数')
-        .setDescription('虚拟机器人玩家数（1–5）')
-        .setRequired(false)
-        .setMinValue(1)
-        .setMaxValue(5));
+const DEFAULT_BOT_COUNT = 3;
+const MIN_BOT_COUNT = 1;
+const MAX_BOT_COUNT = 5;
+const MIN_TURN_SECONDS = 5;
+const MAX_TURN_SECONDS = 300;
+const CHAMBER_COUNT = 6;
 
-async function execute(interaction) {
-    if (!interaction.inGuild()) {
-        await interaction.reply({ content: '❌ 此命令只能在服务器中使用。', flags: MessageFlags.Ephemeral });
-        return;
-    }
-    if (!checkAdminPermission(interaction.member)) {
-        await interaction.reply({ content: getPermissionDeniedMessage(), flags: MessageFlags.Ephemeral });
-        return;
-    }
+const NOT_IN_GUILD_MESSAGE = '❌ 此命令只能在服务器中使用。';
+const UNEXPECTED_ERROR_MESSAGE = '❌ 开启测试局时出现错误，请查看日志。';
+const CHANNEL_BLOCKED_MESSAGE = '🚫 **神秘指令在本频道/子区已被禁用。**';
 
-    // 检查频道禁用
-    if (isChannelBlocked(interaction.guild.id, interaction.channel?.id || interaction.channelId)) {
-        await interaction.reply({ content: '🚫 **神秘指令在本频道/子区已被禁用。**', flags: MessageFlags.Ephemeral });
-        return;
-    }
-
-    const existing = gameManager.getChannelGame(interaction.channel.id);
-    if (existing) {
-        await interaction.reply({ content: '❌ 本频道已有游戏正在进行。', flags: MessageFlags.Ephemeral });
-        return;
-    }
-
-    const botCount = interaction.options.getInteger('机器人人数') ?? 2;
-    await startPressureRoulette(interaction, { testBotCount: botCount });
+function buildData() {
+    return new SlashCommandBuilder()
+        .setName('加压轮盘测试')
+        .setDescription('【测试用】用虚拟机器人凑人数，单人也能跑通整局加压俄罗斯轮盘')
+        .addIntegerOption(option => option
+            .setName('机器人数量')
+            .setDescription(`补几个自动行动的测试机器人（${MIN_BOT_COUNT}-${MAX_BOT_COUNT}，默认 ${DEFAULT_BOT_COUNT}）`)
+            .setMinValue(MIN_BOT_COUNT)
+            .setMaxValue(MAX_BOT_COUNT)
+            .setRequired(false))
+        .addIntegerOption(option => option
+            .setName('回合时限')
+            .setDescription(`每回合多少秒（${MIN_TURN_SECONDS}-${MAX_TURN_SECONDS}，默认 60）`)
+            .setMinValue(MIN_TURN_SECONDS)
+            .setMaxValue(MAX_TURN_SECONDS)
+            .setRequired(false))
+        .addIntegerOption(option => option
+            .setName('子弹巢位')
+            .setDescription(`把第一发子弹钉在第几个弹巢（1-${CHAMBER_COUNT}，不填则随机）`)
+            .setMinValue(1)
+            .setMaxValue(CHAMBER_COUNT)
+            .setRequired(false))
+        .addBooleanOption(option => option
+            .setName('等待招募')
+            .setDescription('true = 照常等 3 分钟招募真人；默认 false，立即开打')
+            .setRequired(false))
+        .addBooleanOption(option => option
+            .setName('保留消息')
+            .setDescription('true = 不删除旧面板，保留整局所有消息（调试用）；默认 false，按 3 条滚动窗口清理')
+            .setRequired(false));
 }
 
-module.exports = { data, execute };
+function createPressureTestCommand({
+    startGame = startPressureRoulette,
+    checkPermission = checkAdminPermission,
+    permissionDeniedMessage = getPermissionDeniedMessage,
+    manager = gameManager,
+} = {}) {
+    const data = buildData();
+
+    async function execute(interaction) {
+        try {
+            if (!interaction.inGuild()) {
+                await interaction.reply({
+                    content: NOT_IN_GUILD_MESSAGE,
+                    flags: MessageFlags.Ephemeral,
+                });
+                return;
+            }
+            if (!checkPermission(interaction.member)) {
+                await interaction.reply({
+                    content: permissionDeniedMessage(),
+                    flags: MessageFlags.Ephemeral,
+                });
+                return;
+            }
+
+            // 检查频道禁用
+            if (isChannelBlocked(interaction.guild.id, interaction.channel?.id || interaction.channelId)) {
+                await interaction.reply({
+                    content: CHANNEL_BLOCKED_MESSAGE,
+                    flags: MessageFlags.Ephemeral,
+                });
+                return;
+            }
+
+            // 测试指令不贰 30 分钟冷却，但仍然尊重玩家锁和频道锁，
+            // 避免把正在进行的那局踩掉。频道锁是四个游戏共用的，
+            // 所以频道里有任意一场神秘游戏时测试局都开不了。
+            const guildId = interaction.guild.id;
+            const userId = interaction.user.id;
+            const channelBusy = manager.getChannelGame(interaction.channelId);
+            if (manager.getPlayerGame(guildId, userId) || channelBusy) {
+                await interaction.reply({
+                    content: '🎮 **这个频道已经有一场神秘游戏在进行了，或者你本人正在别的游戏里。**\n等它结束，或换个频道再开测试局。',
+                    flags: MessageFlags.Ephemeral,
+                });
+                return;
+            }
+
+            const botCount = interaction.options.getInteger('机器人数量') ?? DEFAULT_BOT_COUNT;
+            const turnSeconds = interaction.options.getInteger('回合时限');
+            const bulletChamber = interaction.options.getInteger('子弹巢位') ?? 0;
+            const waitForRecruitment = interaction.options.getBoolean('等待招募') === true;
+            const keepMessages = interaction.options.getBoolean('保留消息') === true;
+
+            await startGame(interaction, {
+                test: {
+                    botCount,
+                    bulletChamber,
+                    immediate: !waitForRecruitment,
+                    keepMessages,
+                },
+                turnDurationMs: turnSeconds ? turnSeconds * 1000 : undefined,
+            });
+        } catch (error) {
+            console.error(
+                `[MysteryPressureTest] 开启测试局失败 (guild=${interaction.guild?.id || 'dm'}, user=${interaction.user?.id}):`,
+                error
+            );
+            try {
+                if (interaction.deferred && !interaction.replied) {
+                    await interaction.editReply({ content: UNEXPECTED_ERROR_MESSAGE });
+                } else if (!interaction.replied) {
+                    await interaction.reply({
+                        content: UNEXPECTED_ERROR_MESSAGE,
+                        flags: MessageFlags.Ephemeral,
+                    });
+                }
+            } catch (replyError) {
+                console.error('[MysteryPressureTest] 回复异常提示失败:', replyError);
+            }
+        }
+    }
+
+    return { data, execute };
+}
+
+const command = createPressureTestCommand();
+
+module.exports = {
+    ...command,
+    createPressureTestCommand,
+};

--- a/src/modules/mystery/utils/mysteryChannelBlocklist.js
+++ b/src/modules/mystery/utils/mysteryChannelBlocklist.js
@@ -1,0 +1,100 @@
+const fs = require('node:fs');
+const path = require('node:path');
+
+const DATA_DIR = path.join(__dirname, '../../../../data', 'mystery');
+if (!fs.existsSync(DATA_DIR)) {
+    fs.mkdirSync(DATA_DIR, { recursive: true });
+}
+
+const BLOCKLIST_FILE = path.join(DATA_DIR, 'channelBlocklist.json');
+
+/**
+ * channelBlocklist.json 结构：
+ * {
+ *   "guildId": {
+ *     "channelId": { "blockedBy": "userId", "blockedAt": 1234567890 }
+ *   }
+ * }
+ *
+ * 支持的频道类型：子区 (thread)、论坛帖子 (forum post)、普通频道。
+ * 子区主 (thread owner) 可以在自己的子区内禁用/启用神秘指令。
+ * 管理员可以在任何频道禁用/启用。
+ */
+
+let cache = null;
+
+function loadBlocklist() {
+    if (cache !== null) return cache;
+    try {
+        if (fs.existsSync(BLOCKLIST_FILE)) {
+            cache = JSON.parse(fs.readFileSync(BLOCKLIST_FILE, 'utf-8'));
+        } else {
+            cache = {};
+        }
+    } catch (error) {
+        console.error('[MysteryBlocklist] 读取频道黑名单失败:', error);
+        cache = {};
+    }
+    return cache;
+}
+
+function saveBlocklist() {
+    try {
+        fs.writeFileSync(BLOCKLIST_FILE, JSON.stringify(cache, null, 2), 'utf-8');
+    } catch (error) {
+        console.error('[MysteryBlocklist] 写入频道黑名单失败:', error);
+    }
+}
+
+/**
+ * 检查指定频道是否被禁用了神秘指令。
+ * @param {string} guildId
+ * @param {string} channelId
+ * @returns {boolean}
+ */
+function isChannelBlocked(guildId, channelId) {
+    const data = loadBlocklist();
+    return !!(data[guildId] && data[guildId][channelId]);
+}
+
+/**
+ * 在指定频道禁用神秘指令。
+ * @param {string} guildId
+ * @param {string} channelId
+ * @param {string} userId 操作者 ID
+ * @returns {boolean} true=新增禁用, false=已经禁用
+ */
+function blockChannel(guildId, channelId, userId) {
+    const data = loadBlocklist();
+    if (!data[guildId]) data[guildId] = {};
+    if (data[guildId][channelId]) return false;
+    data[guildId][channelId] = {
+        blockedBy: userId,
+        blockedAt: Date.now(),
+    };
+    saveBlocklist();
+    return true;
+}
+
+/**
+ * 在指定频道启用神秘指令（移除禁用）。
+ * @param {string} guildId
+ * @param {string} channelId
+ * @returns {boolean} true=已移除禁用, false=本来就没禁用
+ */
+function unblockChannel(guildId, channelId) {
+    const data = loadBlocklist();
+    if (!data[guildId] || !data[guildId][channelId]) return false;
+    delete data[guildId][channelId];
+    if (Object.keys(data[guildId]).length === 0) {
+        delete data[guildId];
+    }
+    saveBlocklist();
+    return true;
+}
+
+module.exports = {
+    isChannelBlocked,
+    blockChannel,
+    unblockChannel,
+};


### PR DESCRIPTION
# 功能说明

Discord 原生的集成权限(Integration Permissions)只能控制到频道级别，无法单独控制子区(thread)。
论坛帖子/子区会继承父频道的权限设置，导致无法在特定子区内禁用神秘指令。

本 PR 新增 `/神秘指令开关` 命令，允许：
- **子区创建者(thread owner)** 在自己创建的子区内禁用/启用所有神秘指令
- **管理员** 在任何频道（包括普通频道和子区）禁用/启用

## 改动内容

### 新增文件
- `src/modules/mystery/utils/mysteryChannelBlocklist.js` — 频道黑名单存储（JSON文件，按 guild + channel 粒度）
- `src/modules/mystery/commands/mysteryToggleCommand.js` — `/神秘指令开关` 命令（含 `禁用` / `启用` 两个子命令）

### 修改文件
- `src/modules/mystery/commands/mysteryCommand.js` — 在 `/神秘指令` 执行入口增加频道黑名单检查
- `src/modules/mystery/commands/pressureTestCommand.js` — 同步增加频道黑名单检查
- `src/core/index.js` — 注册 `/神秘指令开关` 命令

## 使用方式

```
/神秘指令开关 禁用   → 在当前子区/频道禁用所有神秘指令
/神秘指令开关 启用   → 重新启用
```

## 权限模型

- **管理员**：可在普通频道、自己的子区、他人的子区操作
- **子区主**：只能在自己创建的子区内操作
- **普通成员**：无权操作

## 数据存储

黑名单存储在 `data/mystery/channelBlocklist.json`，结构：

```json
{
  "guildId": {
    "channelId": {
      "blockedBy": "userId",
      "blockedAt": 1234567890
    }
  }
}
```

轻量级 JSON 方案，无需额外数据库依赖。